### PR TITLE
15 improve type hints

### DIFF
--- a/pymon/__init__.py
+++ b/pymon/__init__.py
@@ -5,7 +5,7 @@ from .core import (
     cmap,
     creducel,
     creducer,
-    hof_2,
+    hof1,
     hof_3,
     hof_4,
     hof_5,

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -17,6 +17,7 @@ from typing import (
 T = TypeVar("T")
 V = TypeVar("V")
 U = TypeVar("U")
+P = ParamSpec("P")
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,9 +52,11 @@ class Future(MonadContainer[Awaitable[T]]):
         return self.then(func)
 
 
-def returns_future(func: Callable[..., T]):
+def returns_future(func: Callable[P, T]):
+    """Wraps  returned value of async function to `Future`."""
+
     @wraps(func)
-    def wrapper(*args, **kwargs) -> Future[T]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Future[T]:
         match func(*args, **kwargs):
             case Future() as future:
                 return future
@@ -79,9 +82,6 @@ class Pipe(MonadContainer[T]):
 
     def finish(self) -> T:
         return self.value
-
-
-P = ParamSpec("P")
 
 
 def pipeline(func: Callable[P, Pipe[T]]) -> Callable[P, T]:

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -141,9 +141,14 @@ def hof1(func: Callable[Concatenate[A1, P], AResult]):
     return _wrapper
 
 
-def hof_3(func: Callable[[A, B, C], D]):
-    def _wrapper(a: A, b: B) -> Callable[[C], D]:
-        return lambda c: func(a, b, c)
+def hof2(func: Callable[Concatenate[A1, A2, P], AResult]):
+    """Separate first 2 arguments from other."""
+
+    def _wrapper(arg_1: A1, arg_2: A2) -> Callable[P, AResult]:
+        def _func(*args: P.args, **kwargs: P.kwargs) -> AResult:
+            return func(arg_1, arg_2, *args, **kwargs)
+
+        return _func
 
     return _wrapper
 

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -4,7 +4,6 @@ from abc import ABC
 from dataclasses import dataclass
 from functools import reduce, wraps
 from typing import (
-    Any,
     Awaitable,
     Callable,
     Concatenate,
@@ -106,12 +105,19 @@ async def this_async(x: T) -> T:
     return x
 
 
-def returns(x: T) -> Callable[[Any], T]:
-    return lambda _: x
+def returns(x: T) -> Callable[P, T]:
+    """Return `T` on any input."""
+
+    def _returns(*_: P.args, **__: P.kwargs) -> T:
+        return x
+
+    return _returns
 
 
-def returns_async(x: T) -> Callable[[Any], Future[T]]:
-    async def _returns_async(_) -> T:
+def returns_async(x: T) -> Callable[P, Future[T]]:
+    """Return awaitable `T` on any input."""
+
+    async def _returns_async(*_: P.args, **__: P.kwargs) -> T:
         return x
 
     return _returns_async

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Concatenate,
     Generator,
     Generic,
     Iterable,
@@ -119,17 +120,23 @@ def returns_async(x: T) -> Callable[[Any], Future[T]]:
 # curring utils
 # TODO improve annotations for HOFs
 
-A = TypeVar("A")
-B = TypeVar("B")
-C = TypeVar("C")
-D = TypeVar("D")
-E = TypeVar("E")
-F = TypeVar("F")
+A1 = TypeVar("A1")
+A2 = TypeVar("A2")
+A3 = TypeVar("A3")
+A4 = TypeVar("A4")
+A5 = TypeVar("A5")
+A6 = TypeVar("A6")
+AResult = TypeVar("AResult")
 
 
-def hof_2(func: Callable[[A, B], C]):
-    def _wrapper(a: A) -> Callable[[B], C]:
-        return lambda b: func(a, b)
+def hof1(func: Callable[Concatenate[A1, P], AResult]):
+    """Separate first argument from other."""
+
+    def _wrapper(arg_1: A1) -> Callable[P, AResult]:
+        def _func(*args: P.args, **kwargs: P.kwargs) -> AResult:
+            return func(arg_1, *args, **kwargs)
+
+        return _func
 
     return _wrapper
 

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -22,6 +22,7 @@ P = ParamSpec("P")
 
 @dataclass(frozen=True, slots=True)
 class MonadContainer(Generic[T], ABC):
+    """General abstraction for monadic container."""
     value: T
 
 

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -118,14 +118,10 @@ def returns_async(x: T) -> Callable[[Any], Future[T]]:
 
 
 # curring utils
-# TODO improve annotations for HOFs
 
 A1 = TypeVar("A1")
 A2 = TypeVar("A2")
 A3 = TypeVar("A3")
-A4 = TypeVar("A4")
-A5 = TypeVar("A5")
-A6 = TypeVar("A6")
 AResult = TypeVar("AResult")
 
 
@@ -165,28 +161,59 @@ def hof3(func: Callable[Concatenate[A1, A2, A3, P], AResult]):
     return _wrapper
 
 
-def hof_5(func: Callable[[A, B, C, D, E], F]):
-    def _wrapper(a: A, b: B, c: C, d: D) -> Callable[[E], F]:
-        return lambda e: func(a, b, c, d, e)
+@hof2
+def creducel(folder: Callable[[A1, A2], A1], initial: A1, lst: Iterable[A2]) -> A1:
+    """Curried `reduce` left function.
 
-    return _wrapper
+    Args:
+        folder (Callable[[A1, A2], A1]): aggregator.
+        initial (A1): initial aggregation value.
+        lst (Iterable[A2]): data to reduce.
 
-
-@hof_3
-def creducel(folder: Callable[[A, B], A], initial: A, lst: Iterable[B]):
+    Returns:
+        A1: reduction result.
+    """
     return reduce(folder, lst, initial)
 
 
-@hof_3
-def creducer(folder: Callable[[A, B], B], initial: B, lst: Iterable[A]):
+@hof2
+def creducer(folder: Callable[[A1, A2], A2], initial: A2, lst: Iterable[A1]) -> A2:
+    """Curried `reduce` right function.
+
+    Args:
+        folder (Callable[[A1, A2], A2]): aggregator.
+        initial (A2): initial aggregation value.
+        lst (Iterable[A1]): data to reduce.
+
+    Returns:
+        A2: reduction result.
+    """
     return reduce(lambda x, y: folder(y, x), lst[::-1], initial)
 
 
-@hof_2
-def cmap(mapper: Callable[[A], B], lst: Iterable[A]) -> Iterable[B]:
+@hof1
+def cmap(mapper: Callable[[A1], A2], lst: Iterable[A1]) -> Iterable[A2]:
+    """Curreid `map` function.
+
+    Args:
+        mapper (Callable[[A1], A2]): mapper for element of iterable.
+        lst (Iterable[A1]): to map.
+
+    Returns:
+        Iterable[A2]: map result.
+    """
     return map(mapper, lst)
 
 
-@hof_2
-def cfilter(predicate: Callable[[A], bool], lst: Iterable[A]) -> Iterable[A]:
+@hof1
+def cfilter(predicate: Callable[[A1], bool], lst: Iterable[A1]) -> Iterable[A1]:
+    """Curried `filter` function.
+
+    Args:
+        predicate (Callable[[A1], bool]): to filter with.
+        lst (Iterable[A1]): to filter.
+
+    Returns:
+        Iterable[A1]: filtered iterable.
+    """
     return filter(predicate, lst)

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -153,9 +153,14 @@ def hof2(func: Callable[Concatenate[A1, A2, P], AResult]):
     return _wrapper
 
 
-def hof_4(func: Callable[[A, B, C, D], E]):
-    def _wrapper(a: A, b: B, c: C) -> Callable[[D], E]:
-        return lambda d: func(a, b, c, d)
+def hof3(func: Callable[Concatenate[A1, A2, A3, P], AResult]):
+    """Separate first 3 arguments from other."""
+
+    def _wrapper(arg_1: A1, arg_2: A2, arg_3: A3) -> Callable[P, AResult]:
+        def _func(*args: P.args, **kwargs: P.kwargs) -> AResult:
+            return func(arg_1, arg_2, arg_3, *args, **kwargs)
+
+        return _func
 
     return _wrapper
 

--- a/pymon/maybe/core.py
+++ b/pymon/maybe/core.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from typing import Callable, TypeVar
 
-from pymon.core import hof_2
+from pymon.core import hof1
 
 T = TypeVar("T")
 V = TypeVar("V")
@@ -35,7 +35,7 @@ def if_none(func: Callable[[None], V]) -> Callable[[T | None], V | None]:
     return _wrapper
 
 
-@hof_2
+@hof1
 def if_none_returns(replacement: V, value: T | None) -> V | T:
     """Replace `value` with `replacement` if one is `None`.
 

--- a/pymon/maybe/utils.py
+++ b/pymon/maybe/utils.py
@@ -1,12 +1,12 @@
 from typing import Callable, TypeVar
 
-from pymon.core import hof_2
+from pymon.core import hof1
 
 TKey = TypeVar("TKey")
 TValue = TypeVar("TValue")
 
 
-@hof_2
+@hof1
 def maybe_get(key: TKey, dct: dict[TKey, TValue]) -> TValue | None:
     """Maybe get some value from dictionary.
 
@@ -23,7 +23,7 @@ def maybe_get(key: TKey, dct: dict[TKey, TValue]) -> TValue | None:
 T = TypeVar("T")
 
 
-@hof_2
+@hof1
 def some_when(predicate: Callable[[T], bool], data: T) -> T | None:
     """Passes value next only when predicate is True, otherwise returns `None`.
 


### PR DESCRIPTION
- Improve typing for `returns_future` (#15)
- Improve `hof_1` types and rename to `hof1` (#15)
- Improve types `hof_3` adn rename to `hof2` (#15)
- Improve types for `hof_4` and renamde to `hof3` (#15)
- Fix types for utility functions and add docstrings (#15)
- Improve types `returns` and `returns_async` (#15)
- Add docstring for `MonadContainer` (#15)
