### PR TITLE
46 abstraction type over functions

### DIFF
--- a/pymon/core.py
+++ b/pymon/core.py
@@ -224,36 +224,45 @@ A3 = TypeVar("A3")
 AResult = TypeVar("AResult")
 
 
-def hof1(func: Callable[Concatenate[A1, P], AResult]):
+def hof1(f: Callable[Concatenate[A1, P], AResult]):
     """Separate first argument from other."""
 
+    @func
+    @wraps(f)
     def _wrapper(arg_1: A1) -> Callable[P, AResult]:
+        @func
         def _func(*args: P.args, **kwargs: P.kwargs) -> AResult:
-            return func(arg_1, *args, **kwargs)
+            return f(arg_1, *args, **kwargs)
 
         return _func
 
     return _wrapper
 
 
-def hof2(func: Callable[Concatenate[A1, A2, P], AResult]):
+def hof2(f: Callable[Concatenate[A1, A2, P], AResult]):
     """Separate first 2 arguments from other."""
 
+    @func
+    @wraps(f)
     def _wrapper(arg_1: A1, arg_2: A2) -> Callable[P, AResult]:
+        @func
         def _func(*args: P.args, **kwargs: P.kwargs) -> AResult:
-            return func(arg_1, arg_2, *args, **kwargs)
+            return f(arg_1, arg_2, *args, **kwargs)
 
         return _func
 
     return _wrapper
 
 
-def hof3(func: Callable[Concatenate[A1, A2, A3, P], AResult]):
+def hof3(f: Callable[Concatenate[A1, A2, A3, P], AResult]):
     """Separate first 3 arguments from other."""
 
+    @func
+    @wraps(f)
     def _wrapper(arg_1: A1, arg_2: A2, arg_3: A3) -> Callable[P, AResult]:
+        @func
         def _func(*args: P.args, **kwargs: P.kwargs) -> AResult:
-            return func(arg_1, arg_2, arg_3, *args, **kwargs)
+            return f(arg_1, arg_2, arg_3, *args, **kwargs)
 
         return _func
 

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -281,3 +281,33 @@ def cfilter(predicate: Callable[[A1], bool], lst: Iterable[A1]) -> Iterable[A1]:
         Iterable[A1]: filtered iterable.
     """
     return filter(predicate, lst)
+
+
+@dataclass(slots=True, frozen=True)
+class Func(Generic[P, V]):
+    """Function composition abstraction."""
+
+    func: Callable[P, V] = this
+
+    def __call__(self, *args: P.args, **kwds: P.kwargs) -> V:  # noqa
+        return self.func(*args, **kwds)
+
+    def __lshift__(self, other: Callable[[V], U]) -> Func[P, U]:
+        def composition(*args: P.args, **kwargs: P.kwargs) -> U:
+            match self.func(*args, **kwargs):
+                case Future() as future:
+                    return future << other
+                case value:
+                    return other(value)
+
+        return Func(composition)
+
+    def __rshift__(self, other: Callable[[V], Future[U]]) -> Func[P, Future[U]]:
+        def composition(*args: P.args, **kwargs: P.kwargs) -> Future[U]:
+            match self.func(*args, **kwargs):
+                case Future() as future:
+                    return future >> other
+                case value:
+                    return other(value)
+
+        return Func(composition)

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -311,3 +311,8 @@ class Func(Generic[P, V]):
                     return other(value)
 
         return Func(composition)
+
+
+def func(func: Callable[P, V]) -> Func[P, V]:
+    """Decorator for making functions composable."""
+    return Func(func)

--- a/pymon/predicate.py
+++ b/pymon/predicate.py
@@ -1,63 +1,74 @@
 from dataclasses import dataclass
-from typing import Callable, Generic, Iterable, Sized, TypeVar
+from typing import Callable, Iterable, ParamSpec, Sized, TypeVar
 
-T = TypeVar("T")
+from pymon.core import Func, Future
+
+P = ParamSpec("P")
+TBool = TypeVar("TBool", bool, Future[bool])
 
 
-@dataclass(slots=True)
-class Predicate(Generic[T]):
+@dataclass(slots=True, frozen=True)
+class Predicate(Func[P, TBool]):
     """Abstraction over predicates for seamless composition of predicate functions."""
 
-    _predicate: Callable[[T], bool]
+    func: Callable[P, TBool]
 
-    def __init__(self, predicate: Callable[[T], bool]) -> None:
-        self._predicate = predicate
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> TBool:  # noqa
+        return self._predicate(*args, **kwargs)
 
-    def __call__(self, value: T) -> bool:  # noqa
-        return self._predicate(value)
-
-    def _and(self, other: "Predicate[T]") -> "Predicate[T]":
+    def __and__(self, other: "Predicate[P, TBool]") -> "Predicate[P, TBool]":
         return Predicate(lambda v: self._predicate(v) and other._predicate(v))
 
-    def __and__(self, other: "Predicate[T]") -> "Predicate[T]":
-        return self._and(other)
-
-    def _or(self, other: "Predicate[T]") -> "Predicate[T]":
+    def __or__(self, other: "Predicate[P, TBool]") -> "Predicate[P, TBool]":
         return Predicate(lambda v: self._predicate(v) or other._predicate(v))
 
-    def __or__(self, other: "Predicate[T]") -> "Predicate[T]":
-        return self._or(other)
-
-    def _invert(self) -> "Predicate[T]":
+    def __invert__(self) -> "Predicate[P, TBool]":
         return Predicate(lambda v: not self._predicate(v))
 
-    def __invert__(self) -> "Predicate[T]":
-        return self._invert()
 
-
-def predicate(func: Callable[[T], bool]) -> Predicate[T]:
+def predicate(func: Callable[P, TBool]):
     """Makes function composable `Predicate` instance."""
     return Predicate(func)
 
 
-def len_more_then(length: int) -> Predicate[Iterable]:
+def len_more_then(length: int):
     """If `iterable` length is strictly more than `length`."""
-    return Predicate(lambda iterable: length < len(iterable))
+
+    @predicate
+    def _predicate(iterable: Iterable) -> bool:
+        return length < len(iterable)
+
+    return _predicate
 
 
-def len_less_then(length: int) -> Predicate[Iterable]:
+def len_less_then(length: int):
     """If `iterable` length is strictly less than `length`."""
-    return Predicate(lambda iterable: length > len(iterable))
+
+    @predicate
+    def _predicate(iterable: Iterable) -> bool:
+        return length > len(iterable)
+
+    return _predicate
 
 
-def len_less_or_equals(length: int) -> Predicate[Iterable]:
+def len_less_or_equals(length: int):
     """If `iterable` length is less or equals `length`."""
-    return Predicate(lambda iterable: len(iterable) <= length)
+
+    @predicate
+    def _predicate(iterable: Iterable) -> bool:
+        return len(iterable) <= length
+
+    return _predicate
 
 
-def len_more_or_equals(length: int) -> Predicate[Iterable]:
+def len_more_or_equals(length: int):
     """If `iterable` length is more or equals `length`."""
-    return Predicate(lambda iterable: len(iterable) >= length)
+
+    @predicate
+    def _predicate(iterable: Iterable) -> bool:
+        return len(iterable) >= length
+
+    return _predicate
 
 
 TSized = TypeVar("TSized", bound=Sized)

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -2,8 +2,7 @@ from dataclasses import dataclass
 from functools import wraps
 from typing import Awaitable, Callable, ParamSpec, TypeVar
 
-from pymon.core import hof1, this
-from pymon.predicate import Predicate
+from pymon.core import Future, hof1, hof2, returns_future, this, this_async
 
 V = TypeVar("V")
 T = TypeVar("T")
@@ -75,16 +74,15 @@ def safe(func: Callable[P, V]) -> Callable[P, V | Exception]:
     return _wrapper
 
 
-def safe_async(
-    func: Callable[P, Awaitable[V]]
-) -> Callable[P, Awaitable[V | Exception]]:
+def safe_future(func: Callable[P, Awaitable[V]]) -> Callable[P, Future[V | TError]]:
     """Decorator for async function that might raise an exception.
 
     Excepts exception and returns that instead.
     """
 
     @wraps(func)
-    async def _wrapper(*args: P.args, **kwargs: P.kwargs) -> V | Exception:
+    @returns_future
+    async def _wrapper(*args: P.args, **kwargs: P.kwargs) -> V | TError:
         try:
             return await func(*args, **kwargs)
         except Exception() as err:
@@ -93,6 +91,13 @@ def safe_async(
     return _wrapper
 
 
+async def _async_ternary(
+    condition: Future[bool], error: TError, value: T
+) -> Future[T] | Future[TError]:
+    return value if await condition else error
+
+
+@hof2
 def ok_when(predicate: Callable[[T], bool], error: TError, value: T) -> T | TError:
     """Pass value only if predicate is True, otherwise return error.
 
@@ -111,6 +116,23 @@ def ok_when(predicate: Callable[[T], bool], error: TError, value: T) -> T | TErr
             return error
 
 
+@hof2
+def ok_when_future(
+    predicate: Callable[[T], bool], error: TError, value: T
+) -> Future[T] | Future[TError]:
+    """Pass value only if async predicate is True, otherwise return error.
+
+    Args:
+        predicate (Callable[[T], bool]): to fulfill.
+        error (TError): to replace with.
+        value (T): to process.
+
+    Returns:
+        Future[T] | Future[TError]: result.
+    """
+    return Future(_async_ternary(predicate, error, value))
+
+
 @dataclass(slots=True, frozen=True)
 class PolicyViolationError(Exception):
     """Exception that marks that policy is violated."""
@@ -118,7 +140,7 @@ class PolicyViolationError(Exception):
     message: str
 
 
-def check(predicate: Predicate[T]) -> T | PolicyViolationError:
+def check(predicate: Callable[P, bool]) -> T | PolicyViolationError:
     """Pass value next only if predicate is True, otherwise policy is violated.
 
     Args:
@@ -128,6 +150,20 @@ def check(predicate: Predicate[T]) -> T | PolicyViolationError:
         T | PolicyViolationError: result
     """
     return ok_when(predicate, PolicyViolationError(message=str(predicate)))
+
+
+def check_future(
+    predicate: Callable[P, Future[bool]]
+) -> Future[T] | Future[PolicyViolationError]:
+    """Pass value next only if predicate is True, otherwise policy is violated.
+
+    Args:
+        predicate (Callable[P, Future[bool]]): to check.
+
+    Returns:
+        Future[T] | Future[PolicyViolationError]: result.
+    """
+    return ok_when_future(predicate, PolicyViolationError(message=str(predicate)))
 
 
 def choose_ok(*funcs: Callable[[T], V | TError]) -> Callable[[T], V | TError]:
@@ -143,6 +179,36 @@ def choose_ok(*funcs: Callable[[T], V | TError]) -> Callable[[T], V | TError]:
             def _choose(value: T) -> V | TError:
                 for func in funcs:
                     match func(value):
+                        case Exception():
+                            continue
+                        case success:
+                            return success
+
+            return _choose
+
+
+def choose_ok_future(
+    *funcs: Callable[[T], Future[V] | Future[TError]]
+) -> Callable[[T], Future[V] | Future[TError]]:
+    """Combines multiple functions that might return error into one.
+
+    Result of the first function to return non-Exception result is returned.
+    """
+    match funcs:
+        case []:
+            return returns_future(this_async)
+        case _:
+
+            @returns_future
+            async def _choose(value: T) -> V | TError:
+                for func in funcs:
+                    match func(value):
+                        case Future() as f:
+                            match await f:
+                                case Exception():
+                                    continue
+                                case success:
+                                    return success
                         case Exception():
                             continue
                         case success:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,9 @@
+from pymon.core import Func
+
+
+def test_func():
+    f = Func(lambda x: x + 1)
+
+    g = f << (lambda x: x + 3) << (lambda x: x**2)
+
+    assert g(5) == 81

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,6 @@
-from pymon.core import Func
+import pytest
+
+from pymon.core import Func, Future, func, this_async
 
 
 def test_func():
@@ -7,3 +9,25 @@ def test_func():
     g = f << (lambda x: x + 3) << (lambda x: x**2)
 
     assert g(5) == 81
+
+
+def add1(x: int):
+    return x + 1
+
+
+def add3(x: int):
+    return x + 3
+
+
+def power2(x: int):
+    return x**2
+
+
+def minus5(x: int):
+    return Future(this_async(x - 5))
+
+
+@pytest.mark.asyncio
+async def test_func_decorator():
+    f = func(add1) << add3 << power2 >> minus5
+    assert await f(5) == 76


### PR DESCRIPTION
Closes #46

- Add `Func` abstraction (#46)
- Add tests for `Func` (#46)
- Add `@func` decorator for making functions composable (#46)
- Add test for `@func` (#46)
- Move `Func` and `@func` upper in core (#46)
- Use `@func` with `@hof`s (#46)
- Fix `Func` usage in `Predicate` (#46)
- Add `FutureFunc` that separated sync and async functions (#46)
- Rework predicates; Add `FuturePredicate` (#46)
- Rework policy system (#46)
