### PR TITLE
#68 Fix docstrings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,11 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "cSpell.words": [
+        "cfilter",
+        "cmap",
+        "creducel",
+        "creducer"
+    ]
 }

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -316,7 +316,7 @@ def creducer(folder: Callable[[A1, A2], A2], initial: A2, lst: Iterable[A1]) -> 
 
 @hof1
 def cmap(mapper: Callable[[A1], A2], lst: Iterable[A1]) -> Iterable[A2]:
-    """Curreid `map` function.
+    """Curried `map` function.
 
     Args:
         mapper (Callable[[A1], A2]): mapper for element of iterable.

--- a/pymon/pointfree/bytes_utils.py
+++ b/pymon/pointfree/bytes_utils.py
@@ -114,7 +114,7 @@ def removesuffix(suffix: bytes, arg: bytes) -> bytes:
         arg (bytes): to remove from.
 
     Returns:
-        bytes: without suffix if it is possuble.
+        bytes: without suffix if it is possible.
     """
     return arg.removesuffix(suffix)
 

--- a/pymon/pointfree/bytes_utils.py
+++ b/pymon/pointfree/bytes_utils.py
@@ -63,7 +63,7 @@ def find(sub: bytes, arg: bytes) -> int | None:
     """Point-free maybe version of `bytes.find`.
 
     Args:
-        sub (bytes): to serach.
+        sub (bytes): to search.
         arg (bytes): to search int.
 
     Returns:

--- a/pymon/pointfree/bytes_utils.py
+++ b/pymon/pointfree/bytes_utils.py
@@ -25,7 +25,7 @@ def count(sub: bytes, arg: bytes) -> int:
         arg (bytes): to count in.
 
     Returns:
-        int: number of occurances of `pattern` in `arg`.
+        int: number of occurrences of `pattern` in `arg`.
     """
     return arg.count(sub)
 

--- a/pymon/pointfree/bytes_utils.py
+++ b/pymon/pointfree/bytes_utils.py
@@ -5,15 +5,15 @@ from pymon.result.core import safe
 
 
 @hof2
-def center(length: SupportsIndex, fillchar: bytes, arg: bytes) -> bytes:
+def center(length: SupportsIndex, fill_char: bytes, arg: bytes) -> bytes:
     """Point-free version of `bytes.center`.
 
     Args:
         length (SupportsIndex): of result bytestring.
-        fillchar (bytes): to fill `bytes` around.
+        fill_char (bytes): to fill `bytes` around.
         arg (bytes): to centralize.
     """
-    return arg.center(length, fillchar)
+    return arg.center(length, fill_char)
 
 
 @hof3

--- a/pymon/pointfree/dict_utils.py
+++ b/pymon/pointfree/dict_utils.py
@@ -27,7 +27,7 @@ def try_get(key: TKey, arg: dict[TKey, TValue]) -> TValue:
 
 @hof1
 def maybe_get(key: TKey, arg: dict[TKey, TValue]) -> TValue | None:
-    """Point-free versuib if `dict.get` with default `None`.
+    """Point-free version if `dict.get` with default `None`.
 
     Args:
         key (TKey): to get.

--- a/pymon/pointfree/str_utils.py
+++ b/pymon/pointfree/str_utils.py
@@ -25,7 +25,7 @@ def count(sub: str, arg: str) -> int:
         arg (str): to count in.
 
     Returns:
-        int: number of occurances of `pattern` in `arg`.
+        int: number of occurrences of `pattern` in `arg`.
     """
     return arg.count(sub)
 

--- a/pymon/pointfree/str_utils.py
+++ b/pymon/pointfree/str_utils.py
@@ -63,7 +63,7 @@ def find(sub: str, arg: str) -> int | None:
     """Point-free maybe version of `str.find`.
 
     Args:
-        sub (str): to serach.
+        sub (str): to search.
         arg (str): to search int.
 
     Returns:

--- a/pymon/pointfree/str_utils.py
+++ b/pymon/pointfree/str_utils.py
@@ -92,17 +92,17 @@ def index(sub: str, arg: str) -> int:
 
 
 @hof1
-def join_by(concatenator: str, arg: Iterable[str]) -> str:
-    """Join incoming `Iterable[str]` by some `concatenatror`.
+def join_by(concatenation: str, arg: Iterable[str]) -> str:
+    """Join incoming `Iterable[str]` by some `concatenation`.
 
     Args:
-        concatenator (str): to join with.
+        concatenation (str): to join with.
         arg (Iterable[str]): to be joined.
 
     Returns:
         str: joined string.
     """
-    return concatenator.join(arg)
+    return concatenation.join(arg)
 
 
 @hof1

--- a/pymon/pointfree/str_utils.py
+++ b/pymon/pointfree/str_utils.py
@@ -5,15 +5,15 @@ from pymon.result import safe
 
 
 @hof2
-def center(length: SupportsIndex, fillchar: str, arg: str) -> str:
+def center(length: SupportsIndex, fill_char: str, arg: str) -> str:
     """Point-free version of `str.center`.
 
     Args:
         length (SupportsIndex): of result string.
-        fillchar (str): to fill `str` around.
+        fill_char (str): to fill `str` around.
         arg (str): to centralize.
     """
-    return arg.center(length, fillchar)
+    return arg.center(length, fill_char)
 
 
 @hof3


### PR DESCRIPTION
- Fix bytes `conter` pf func docs (#68)
- Fix bytes `count` docstring (#68)
- Fix bytes `find` docstring (#68)
- Fix bytes `removesuffix` docstring  (#68)
- Fix str `conter` docstring (#68)
- Fix str `count` docstring (#68)
- Fix str `find` docstring (#68)
- Fix str `join_by` docstring (#68)
- Fix dict `maybe_get` docstring (#68)
- Fix `cmap` docstring (#68)
- Add creducel, creducer, cmap, cfilter to workspace dictionary (#68)
