### PR TITLE
#81 Rework `Predicate` and `FuturePredicate`

### DIFF
--- a/pymon/predicate.py
+++ b/pymon/predicate.py
@@ -1,118 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Awaitable, Callable, Iterable, ParamSpec, Sized, TypeVar
-
-from pymon.core import _compose_future, compose
-
-P = ParamSpec("P")
-
-
-class FuturePredicate(_compose_future[P, bool]):
-    """Abstraction over async predicates."""
-
-    func: Callable[P, Awaitable[bool]]
-
-    def __mul__(self, other: Callable[P, bool]) -> FuturePredicate[P]:
-        def _mul(other: Callable[P, Awaitable[bool]]):
-            async def __mul(*args: P.args, **kwargs: P.kwargs) -> bool:
-                return await self.func(*args, **kwargs) and other(*args, **kwargs)
-
-            return __mul
-
-        return FuturePredicate(_mul(other))
-
-    def __add__(self, other: Callable[P, bool]) -> FuturePredicate[P]:
-        def _add(other: Callable[P, Awaitable[bool]]):
-            async def __add(*args: P.args, **kwargs: P.kwargs) -> bool:
-                return await self.func(*args, **kwargs) or other(*args, **kwargs)
-
-            return __add
-
-        return FuturePredicate(_add(other))
-
-    def __and__(self, other: Callable[P, Awaitable[bool]]) -> FuturePredicate[P]:
-        def _and(other: Callable[P, Awaitable[bool]]):
-            async def __and(*args: P.args, **kwargs: P.kwargs) -> bool:
-                return await self.func(*args, **kwargs) and await other(*args, **kwargs)
-
-            return __and
-
-        return FuturePredicate(_and(other))
-
-    def __or__(self, other: Callable[P, Awaitable[bool]]) -> Predicate[P]:
-        def _or(other: Callable[P, Awaitable[bool]]):
-            async def __or(*args: P.args, **kwargs: P.kwargs) -> bool:
-                return await self.func(*args, **kwargs) or await other(*args, **kwargs)
-
-            return __or
-
-        return FuturePredicate(_or(other))
-
-    def __invert__(self) -> FuturePredicate[P]:
-        async def _invert(*args, **kwargs) -> bool:
-            return not await self.func(*args, **kwargs)
-
-        return FuturePredicate(_invert)
-
-
-@dataclass(slots=True, frozen=True)
-class Predicate(compose[P, bool]):
-    """Abstraction over predicates."""
-
-    func: Callable[P, bool]
-
-    def __mul__(self, other: Callable[P, bool]) -> Predicate[P]:
-        def _mul(*args: P.args, **kwargs: P.kwargs) -> bool:
-            return self.func(*args, **kwargs) and other(*args, **kwargs)
-
-        return Predicate(_mul)
-
-    def __add__(self, other: Callable[P, bool]) -> Predicate[P]:
-        def _add(*args: P.args, **kwargs: P.kwargs) -> bool:
-            return self.func(*args, **kwargs) or other(*args, **kwargs)
-
-        return Predicate(_add)
-
-    def __and__(self, other: Callable[P, Awaitable[bool]]) -> FuturePredicate[P]:
-        def _and(other: Callable[P, Awaitable[bool]]):
-            async def __and(*args: P.args, **kwargs: P.kwargs) -> bool:
-                return self.func(*args, **kwargs) and await other(*args, **kwargs)
-
-            return __and
-
-        return FuturePredicate(_and(other))
-
-    def __or__(self, other: Callable[P, Awaitable[bool]]) -> FuturePredicate[P]:
-        def _or(other: Callable[P, Awaitable[bool]]):
-            async def __or(*args: P.args, **kwargs: P.kwargs) -> bool:
-                return self.func(*args, **kwargs) or await other(*args, **kwargs)
-
-            return __or
-
-        return FuturePredicate(_or(other))
-
-    def __invert__(self) -> Predicate[P]:
-        def _invert(*args: P.args, **kwargs: P.kwargs):
-            return not self.func(*args, **kwargs)
-
-        return Predicate(_invert)
-
-
-def predicate(p: Callable[P, bool]):
-    """Makes function composable `Predicate` instance."""
-    return Predicate(p)
-
-
-def future_predicate(p: Callable[P, Awaitable[bool]]):
-    """Makes function composable `FuturePredicate` instance."""
-    return FuturePredicate(p)
+from typing import Iterable, Sized, TypeVar
 
 
 def len_more_then(length: int):
     """If `iterable` length is strictly more than `length`."""
 
-    @predicate
     def _predicate(iterable: Iterable) -> bool:
         return length < len(iterable)
 
@@ -122,7 +15,6 @@ def len_more_then(length: int):
 def len_less_then(length: int):
     """If `iterable` length is strictly less than `length`."""
 
-    @predicate
     def _predicate(iterable: Iterable) -> bool:
         return length > len(iterable)
 
@@ -132,7 +24,6 @@ def len_less_then(length: int):
 def len_less_or_equals(length: int):
     """If `iterable` length is less or equals `length`."""
 
-    @predicate
     def _predicate(iterable: Iterable) -> bool:
         return len(iterable) <= length
 
@@ -142,7 +33,6 @@ def len_less_or_equals(length: int):
 def len_more_or_equals(length: int):
     """If `iterable` length is more or equals `length`."""
 
-    @predicate
     def _predicate(iterable: Iterable) -> bool:
         return len(iterable) >= length
 
@@ -152,13 +42,11 @@ def len_more_or_equals(length: int):
 TSized = TypeVar("TSized", bound=Sized)
 
 
-@predicate
 def is_empty(obj: TSized) -> bool:
     """If `obj` is empty."""
     return len(obj) == 0
 
 
-@predicate
 def is_not_empty(obj: TSized) -> bool:
     """If `obj` is not empty."""
     return len(obj) != 0

--- a/pymon/predicate.py
+++ b/pymon/predicate.py
@@ -65,6 +65,64 @@ class each(Generic[P]):  # noqa
         return ef >> nxt
 
 
+@dataclass(slots=True, init=False)
+class _one_future(Generic[P]):  # noqa
+
+    sync_predicates: list[Callable[P, bool]]
+    async_predicates: list[Callable[P, Awaitable[bool]]]
+
+    def __init__(self) -> None:
+        self.sync_predicates = []
+        self.async_predicates = []
+
+    @future.returns
+    async def __call__(self, *args: P.args, **_: P.kwargs) -> bool:
+        if (
+            any(sync_predicate(*args) for sync_predicate in self.sync_predicates)
+            is True
+        ):
+            return True
+
+        for async_predicate in self.async_predicates:
+            if await async_predicate(*args) is True:
+                return True
+
+        return False
+
+    def __lshift__(self, nxt: Callable[P, bool]) -> _each_future[P]:
+        self.sync_predicates.append(nxt)
+        return self
+
+    def __rshift__(self, nxt: Callable[P, Awaitable[bool]]) -> _each_future[P]:
+        self.async_predicates.append(nxt)
+        return self
+
+
+@dataclass(slots=True, init=False)
+class one(Generic[P]):  # noqa
+    """Mathematical disjunction of predicates."""
+
+    predicates: list[Callable[P, bool]]
+
+    def __init__(self) -> None:
+        self.predicates = []
+
+    def __call__(self, *args: P.args, **_: P.kwargs) -> bool:  # noqa
+        return any(predicate(*args) for predicate in self.predicates)
+
+    def __lshift__(self, nxt: Callable[P, bool]) -> one[P]:
+        self.predicates.append(nxt)
+        return self
+
+    def __rshift__(self, nxt: Callable[P, Awaitable[bool]]) -> _one_future[P]:
+        ef = _one_future()
+
+        for predicate in self.predicates:
+            ef = ef << predicate
+
+        return ef >> nxt
+
+
 def len_more_then(length: int):
     """If `iterable` length is strictly more than `length`."""
 

--- a/pymon/predicate.py
+++ b/pymon/predicate.py
@@ -1,6 +1,68 @@
 from __future__ import annotations
 
-from typing import Iterable, Sized, TypeVar
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Generic, Iterable, ParamSpec, Sized, TypeVar
+
+from pymon.core import future
+
+P = ParamSpec("P")
+
+
+@dataclass(slots=True, init=False)
+class _each_future(Generic[P]):  # noqa
+    sync_predicates: list[Callable[P, bool]]
+    async_predicates: list[Callable[P, Awaitable[bool]]]
+
+    def __init__(self) -> None:
+        self.sync_predicates = []
+        self.async_predicates = []
+
+    @future.returns
+    async def __call__(self, *args: P.args, **_: P.kwargs) -> bool:
+        if (
+            all(sync_predicate(*args) for sync_predicate in self.sync_predicates)
+            is False
+        ):
+            return False
+
+        for async_predicate in self.async_predicates:
+            if await async_predicate(*args) is False:
+                return False
+
+        return True
+
+    def __lshift__(self, nxt: Callable[P, bool]) -> _each_future[P]:
+        self.sync_predicates.append(nxt)
+        return self
+
+    def __rshift__(self, nxt: Callable[P, Awaitable[bool]]) -> _each_future[P]:
+        self.async_predicates.append(nxt)
+        return self
+
+
+@dataclass(slots=True, init=False)
+class each(Generic[P]):  # noqa
+    """Mathematical conjunction of predicates."""
+
+    predicates: list[Callable[P, bool]]
+
+    def __init__(self) -> None:
+        self.predicates = []
+
+    def __call__(self, *args: P.args, **_: P.kwargs) -> bool:  # noqa
+        return all(predicate(*args) for predicate in self.predicates)
+
+    def __lshift__(self, nxt: Callable[P, bool]) -> each[P]:
+        self.predicates.append(nxt)
+        return self
+
+    def __rshift__(self, nxt: Callable[P, Awaitable[bool]]) -> _each_future[P]:
+        ef = _each_future()
+
+        for predicate in self.predicates:
+            ef = ef << predicate
+
+        return ef >> nxt
 
 
 def len_more_then(length: int):

--- a/pymon/predicate.py
+++ b/pymon/predicate.py
@@ -42,7 +42,19 @@ class _each_future(Generic[P]):  # noqa
 
 @dataclass(slots=True, init=False)
 class each(Generic[P]):  # noqa
-    """Mathematical conjunction of predicates."""
+    """Mathematical conjunction of predicates.
+
+    If no predicate passed returns True.
+
+    Example::
+
+            # returns True if number is between 3 and 10
+            p: Callable[[int], bool] = (
+                each()
+                << (lambda x: x > 3)
+                << (lambda x: x < 10)
+            )
+    """
 
     predicates: list[Callable[P, bool]]
 
@@ -100,7 +112,19 @@ class _one_future(Generic[P]):  # noqa
 
 @dataclass(slots=True, init=False)
 class one(Generic[P]):  # noqa
-    """Mathematical disjunction of predicates."""
+    """Mathematical disjunction of predicates.
+
+    If no predicate passed returns False.
+
+    Example::
+
+            # returns True for any number that is less than 3 or more than 10
+            p: Callable[[int], bool] = (
+                one()
+                << (lambda x < 3)
+                << (lambda x > 10)
+            )
+    """
 
     predicates: list[Callable[P, bool]]
 

--- a/tests/test_predicate.py
+++ b/tests/test_predicate.py
@@ -89,3 +89,13 @@ async def test_one_sync_and_async():
     assert await e(6) is True
     assert await e(7) is True
     assert await e(15) is True
+
+
+def test_one_returns_false():
+    o = one()
+    assert o(1) is False
+
+
+def test_each_returns_true():
+    e = each()
+    assert e(1) is True

--- a/tests/test_predicate.py
+++ b/tests/test_predicate.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pymon.predicate import each
+from pymon.predicate import each, one
 
 
 @pytest.mark.parametrize(
@@ -49,3 +49,43 @@ async def test_each_sync_and_async():
     assert await e(6) is True
     assert await e(7) is False
     assert await e(15) is False
+
+
+@pytest.mark.parametrize(
+    "predicates, arg, result",
+    [
+        ([(lambda x: x > 3)], 5, True),
+        ([(lambda x: x > 3), (lambda x: x < 10)], 20, True),
+    ],
+)
+def test_one_sync_only(predicates, arg, result):
+    e = one()
+    for predicate in predicates:
+        e = e << predicate
+
+    assert e(arg) == result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "predicates, arg, result",
+    [
+        ([more_than_3], 5, True),
+        ([more_than_3, less_than_10], 20, True),
+    ],
+)
+async def test_one_async_only(predicates, arg, result):
+    e = one()
+    for predicate in predicates:
+        e = e >> predicate
+
+    assert await e(arg) == result
+
+
+@pytest.mark.asyncio
+async def test_one_sync_and_async():
+    e = one() << (lambda x: x % 2 == 0) >> (more_than_3) >> (less_than_10)
+
+    assert await e(6) is True
+    assert await e(7) is True
+    assert await e(15) is True

--- a/tests/test_predicate.py
+++ b/tests/test_predicate.py
@@ -1,0 +1,51 @@
+import pytest
+
+from pymon.predicate import each
+
+
+@pytest.mark.parametrize(
+    "predicates, arg, result",
+    [
+        ([(lambda x: x > 3)], 5, True),
+        ([(lambda x: x > 3), (lambda x: x < 10)], 20, False),
+    ],
+)
+def test_each_sync_only(predicates, arg, result):
+    e = each()
+    for predicate in predicates:
+        e = e << predicate
+
+    assert e(arg) == result
+
+
+async def more_than_3(x: int) -> bool:
+    return x > 3
+
+
+async def less_than_10(x: int) -> bool:
+    return x < 10
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "predicates, arg, result",
+    [
+        ([more_than_3], 5, True),
+        ([more_than_3, less_than_10], 20, False),
+    ],
+)
+async def test_each_async_only(predicates, arg, result):
+    e = each()
+    for predicate in predicates:
+        e = e >> predicate
+
+    assert await e(arg) == result
+
+
+@pytest.mark.asyncio
+async def test_each_sync_and_async():
+    e = each() << (lambda x: x % 2 == 0) >> (more_than_3) >> (less_than_10)
+
+    assert await e(6) is True
+    assert await e(7) is False
+    assert await e(15) is False


### PR DESCRIPTION
- Remove old `Predicate` and `FuturePredicate` (#81)
- Add `each` and `_each_future` predicate composition classes (#81)
- Add tests for for `each` (#81)
- Add `one` and `_one_future` class for predicate disjunction (#81)
- Add tests for `one` predicate composition class (#81)
- Add tests for empty predicate compositions  (#81)
- Add example in docstring for `each` and `one` (#81)
