### PR TITLE
#83 Rework `check` and `check_future`

### DIFF
--- a/pymon/result.py
+++ b/pymon/result.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from functools import wraps
 from typing import Awaitable, Callable, ParamSpec, TypeVar
 
@@ -133,39 +132,6 @@ def ok_when_future(
         Future[T] | Future[TError]: result.
     """
     return future(__ok_when_future(predicate, create_error, value))
-
-
-@dataclass(slots=True, frozen=True)
-class PolicyViolationError(Exception):
-    """Exception that marks that policy is violated."""
-
-    message: str
-
-
-def check(predicate: Callable[P, bool]) -> T | PolicyViolationError:
-    """Pass value next only if predicate is True, otherwise policy is violated.
-
-    Args:
-        predicate (Predicate[T]): to check.
-
-    Returns:
-        T | PolicyViolationError: result
-    """
-    return ok_when(predicate, PolicyViolationError(message=str(predicate)))
-
-
-def check_future(
-    predicate: Callable[P, Awaitable[bool]]
-) -> future[T] | future[PolicyViolationError]:
-    """Pass value next only if predicate is True, otherwise policy is violated.
-
-    Args:
-        predicate (Callable[P, Future[bool]]): to check.
-
-    Returns:
-        Future[T] | Future[PolicyViolationError]: result.
-    """
-    return ok_when_future(predicate, PolicyViolationError(message=str(predicate)))
 
 
 def choose_ok(*funcs: Callable[[T], V | TError]) -> Callable[[T], V | TError]:

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -96,6 +96,10 @@ def check(
 ) -> T | TError:
     """Pass value only if predicate is True, otherwise return error.
 
+    Examples::
+
+            policy = check(lambda x: x > 10, lambda _: Exception("More than 10"))
+
     Args:
         predicate (Callable[[T], bool]): to fulfill.
         create_error (Callable[[T], TError]): factory function for error.
@@ -123,13 +127,17 @@ def check_future(
 ) -> future[T] | future[TError]:
     """Pass value only if async predicate is True, otherwise return error.
 
+    Examples::
+
+            policy = check_future(more_than_10, lambda _: Exception("More than 10"))
+
     Args:
         predicate (Callable[[T], bool]): to fulfill.
         create_error (Callable[[T], TError]): factory function for error.
         value (T): to process.
 
     Returns:
-        Future[T] | Future[TError]: result.
+        future[T] | future[TError]: result.
     """
     return future(__check_future(predicate, create_error, value))
 

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -91,7 +91,7 @@ def safe_future(func: Callable[P, Awaitable[V]]) -> Callable[P, future[V | TErro
 
 
 @hof2
-def ok_when(
+def check(
     predicate: Callable[[T], bool], create_error: Callable[[T], TError], value: T
 ) -> T | TError:
     """Pass value only if predicate is True, otherwise return error.
@@ -107,7 +107,7 @@ def ok_when(
     return value if predicate(value) else create_error(value)
 
 
-async def __ok_when_future(
+async def __check_future(
     predicate: Callable[[T], Awaitable[bool]],
     create_error: Callable[[T], TError],
     value: T,
@@ -116,7 +116,7 @@ async def __ok_when_future(
 
 
 @hof2
-def ok_when_future(
+def check_future(
     predicate: Callable[[T], Awaitable[bool]],
     create_error: Callable[[T], TError],
     value: T,
@@ -131,7 +131,7 @@ def ok_when_future(
     Returns:
         Future[T] | Future[TError]: result.
     """
-    return future(__ok_when_future(predicate, create_error, value))
+    return future(__check_future(predicate, create_error, value))
 
 
 def choose_ok(*funcs: Callable[[T], V | TError]) -> Callable[[T], V | TError]:


### PR DESCRIPTION
- Replace static error with error factory function (#83)
- Remove old `check` and `check_future` (#83)
- Rename `ok_when` and `ok_when_future` to `check` and `check_future`  (#83)
- Add examples in docstring for `check` and `check_future` (#83)
