### PR TITLE
#30 Tests and codecov

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,3 +37,13 @@ jobs:
       - name: Test with pytest
         run: |
           poetry run pytest
+      - name: Generate Report
+        run: |
+          poetry run pytest --cov=./ --cov-report=xml
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "*/tests/*"

--- a/pymon/maybe.py
+++ b/pymon/maybe.py
@@ -93,6 +93,27 @@ def some_when(predicate: Callable[[T], bool], data: T) -> T | None:
     return data if predicate(data) else None
 
 
+@hof1
+@future.returns
+async def some_when_future(
+    predicate: Callable[[T], Awaitable[bool]], data: T
+) -> T | None:
+    """Passes value next only when predicate is True, otherwise returns `None`.
+
+    Examples::
+
+            policy = some_when_future(more_than_3)
+
+    Args:
+        predicate (Callable[[T], bool]): to fulfill.
+        data (T): to process.
+
+    Returns:
+        T | None: result.
+    """
+    return data if await predicate(data) else None
+
+
 P = ParamSpec("P")
 
 

--- a/pymon/maybe.py
+++ b/pymon/maybe.py
@@ -79,6 +79,10 @@ def if_some_returns(replacement: V, value: T) -> V | T:
 def some_when(predicate: Callable[[T], bool], data: T) -> T | None:
     """Passes value next only when predicate is True, otherwise returns `None`.
 
+    Examples::
+
+            policy = some_when(lambda x: x > 3)
+
     Args:
         predicate (Callable[[T], bool]): to fulfill.
         data (T): to process.

--- a/pymon/maybe.py
+++ b/pymon/maybe.py
@@ -86,11 +86,7 @@ def some_when(predicate: Callable[[T], bool], data: T) -> T | None:
     Returns:
         T | None: result.
     """
-    match predicate(data):
-        case True:
-            return data
-        case False:
-            return None
+    return data if predicate(data) else None
 
 
 P = ParamSpec("P")

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -95,14 +95,14 @@ def safe_future(func: Callable[P, Awaitable[V]]) -> Callable[P, future[V | TErro
 
 
 @hof2
-def check(
+def ok_when(
     predicate: Callable[[T], bool], create_error: Callable[[T], TError], value: T
 ) -> T | TError:
     """Pass value only if predicate is True, otherwise return error.
 
     Examples::
 
-            policy = check(lambda x: x > 10, lambda _: Exception("More than 10"))
+            policy = ok_when(lambda x: x > 10, lambda _: Exception("More than 10"))
 
     Args:
         predicate (Callable[[T], bool]): to fulfill.
@@ -115,7 +115,7 @@ def check(
     return value if predicate(value) else create_error(value)
 
 
-async def __check_future(
+async def __ok_when_future(
     predicate: Callable[[T], Awaitable[bool]],
     create_error: Callable[[T], TError],
     value: T,
@@ -124,7 +124,7 @@ async def __check_future(
 
 
 @hof2
-def check_future(
+def ok_when_future(
     predicate: Callable[[T], Awaitable[bool]],
     create_error: Callable[[T], TError],
     value: T,
@@ -133,7 +133,7 @@ def check_future(
 
     Examples::
 
-            policy = check_future(more_than_10, lambda _: Exception("More than 10"))
+            policy = ok_when_future(more_than_10, lambda _: Exception("More than 10"))
 
     Args:
         predicate (Callable[[T], bool]): to fulfill.
@@ -143,7 +143,7 @@ def check_future(
     Returns:
         future[T] | future[TError]: result.
     """
-    return future(__check_future(predicate, create_error, value))
+    return future(__ok_when_future(predicate, create_error, value))
 
 
 class EmptyChooseOkError(Exception):

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -89,7 +89,7 @@ def safe(func: Callable[P, V]) -> Callable[P, V | Exception]:
     def _wrapper(*args: P.args, **kwargs: P.kwargs) -> V | Exception:
         try:
             return func(*args, **kwargs)
-        except Exception() as err:
+        except Exception as err:
             return err
 
     return _wrapper
@@ -106,7 +106,7 @@ def safe_future(func: Callable[P, Awaitable[V]]) -> Callable[P, future[V | TErro
     async def _wrapper(*args: P.args, **kwargs: P.kwargs) -> V | TError:
         try:
             return await func(*args, **kwargs)
-        except Exception() as err:
+        except Exception as err:
             return err
 
     return _wrapper

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -41,6 +41,24 @@ def if_error(func: Callable[[T], V]):
 
 
 @hof1
+def if_ok_returns(replacement: V, value: T) -> V | T:
+    """Replace `value` with `replacement` if one is not `Exception`.
+
+    Args:
+        replacement (V): to replace with.
+        value (T): to replace.
+
+    Returns:
+        V | T: error-safe result.
+    """
+    match value:
+        case Exception() as err:
+            return err
+        case _:
+            return replacement
+
+
+@hof1
 def if_error_returns(replacement: V, value: T) -> V | T:
     """Replace `value` with `replacement` if one is `Exception`.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,7 @@ import inspect
 
 import pytest
 
-from pymon.core import compose, future, pipe, returns, this, this_future
+from pymon.core import compose, future, pipe, returns, returns_future, this, this_future
 
 
 @pytest.mark.parametrize(
@@ -148,3 +148,14 @@ def test_returns(arg):
     assert r(arg) == arg
     assert r(some="wow") == arg
     assert r(5, 3, 2) == arg
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("arg", [{}, 1, 2, -1, "hello"])
+async def test_returns_future(arg):
+    r = returns_future(arg)
+
+    for fv in [r(), r(arg), r(some="wow"), r(5, 3, 2)]:
+        assert inspect.isawaitable(fv)
+        assert isinstance(fv, future)
+        assert await fv == arg

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,8 @@
+import inspect
+
 import pytest
 
-from pymon.core import compose
+from pymon.core import compose, future
 
 
 @pytest.mark.parametrize(
@@ -59,3 +61,15 @@ async def test_compose_sync_async():
         << (lambda t: not t)
     )
     assert await f(3) is False
+
+
+async def async_identity(x):
+    return x
+
+
+@pytest.mark.asyncio
+async def test_future():
+    fv = future(async_identity(3))
+
+    assert inspect.isawaitable(fv)
+    assert await fv == 3

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -73,3 +73,13 @@ async def test_future():
 
     assert inspect.isawaitable(fv)
     assert await fv == 3
+
+
+@pytest.mark.asyncio
+async def test_future_returns():
+    async_identity_future = future.returns(async_identity)
+
+    fv = async_identity_future(3)
+
+    assert inspect.isawaitable(fv)
+    assert await fv == 3

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,7 @@ import inspect
 
 import pytest
 
-from pymon.core import compose, future
+from pymon.core import compose, future, pipe
 
 
 @pytest.mark.parametrize(
@@ -99,3 +99,10 @@ async def test_future_rshift():
 
     assert inspect.isawaitable(fv)
     assert await fv == 4
+
+
+def test_pipe_lshift():
+    pl = pipe(3) << (lambda x: x + 3)
+
+    assert isinstance(pl, pipe)
+    assert pl.value == 6

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -83,3 +83,11 @@ async def test_future_returns():
 
     assert inspect.isawaitable(fv)
     assert await fv == 3
+
+
+@pytest.mark.asyncio
+async def test_future_lshift():
+    fv = future(async_identity(3)) << (lambda x: x + 1)
+
+    assert inspect.isawaitable(fv)
+    assert await fv == 4

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -119,3 +119,8 @@ async def test_pipe_rshift():
 def test_pipe_finish():
     pl = pipe(3) << (lambda x: x + 3)
     assert pl.finish() == 6
+
+
+def test_pipe_returns():
+    f = pipe.returns(lambda x: pipe(x) >> (lambda x: x + 3))
+    assert f(3) == 6

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -91,3 +91,11 @@ async def test_future_lshift():
 
     assert inspect.isawaitable(fv)
     assert await fv == 4
+
+
+@pytest.mark.asyncio
+async def test_future_rshift():
+    fv = future(async_identity(3)) >> add_1
+
+    assert inspect.isawaitable(fv)
+    assert await fv == 4

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,7 @@ import inspect
 
 import pytest
 
-from pymon.core import compose, future, pipe
+from pymon.core import compose, future, pipe, this
 
 
 @pytest.mark.parametrize(
@@ -124,3 +124,8 @@ def test_pipe_finish():
 def test_pipe_returns():
     f = pipe.returns(lambda x: pipe(x) >> (lambda x: x + 3))
     assert f(3) == 6
+
+
+@pytest.mark.parametrize("arg", [{}, 1, 2, -1, "hello"])
+def test_this(arg):
+    assert this(arg) == arg

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -106,3 +106,11 @@ def test_pipe_lshift():
 
     assert isinstance(pl, pipe)
     assert pl.value == 6
+
+
+@pytest.mark.asyncio
+async def test_pipe_rshift():
+    pl = pipe(3) >> add_1
+
+    assert isinstance(pl, future)
+    assert await pl == 4

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,7 @@ import inspect
 
 import pytest
 
-from pymon.core import compose, future, pipe, this, this_future
+from pymon.core import compose, future, pipe, returns, this, this_future
 
 
 @pytest.mark.parametrize(
@@ -139,3 +139,12 @@ async def test_this_future(arg):
     assert inspect.isawaitable(fv)
     assert isinstance(fv, future)
     assert await fv == arg
+
+
+@pytest.mark.parametrize("arg", [{}, 1, 2, -1, "hello"])
+def test_returns(arg):
+    r = returns(arg)
+    assert r() == arg
+    assert r(arg) == arg
+    assert r(some="wow") == arg
+    assert r(5, 3, 2) == arg

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -114,3 +114,8 @@ async def test_pipe_rshift():
 
     assert isinstance(pl, future)
     assert await pl == 4
+
+
+def test_pipe_finish():
+    pl = pipe(3) << (lambda x: x + 3)
+    assert pl.finish() == 6

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,7 @@ import inspect
 
 import pytest
 
-from pymon.core import compose, future, pipe, this
+from pymon.core import compose, future, pipe, this, this_future
 
 
 @pytest.mark.parametrize(
@@ -129,3 +129,13 @@ def test_pipe_returns():
 @pytest.mark.parametrize("arg", [{}, 1, 2, -1, "hello"])
 def test_this(arg):
     assert this(arg) == arg
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("arg", [{}, 1, 2, -1, "hello"])
+async def test_this_future(arg):
+    fv = this_future(arg)
+
+    assert inspect.isawaitable(fv)
+    assert isinstance(fv, future)
+    assert await fv == arg

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -1,6 +1,12 @@
 import pytest
 
-from pymon.maybe import choose_some, choose_some_future, if_some, if_some_returns
+from pymon.maybe import (
+    choose_some,
+    choose_some_future,
+    if_none,
+    if_some,
+    if_some_returns,
+)
 
 
 @pytest.mark.parametrize(
@@ -12,6 +18,17 @@ from pymon.maybe import choose_some, choose_some_future, if_some, if_some_return
 )
 def test_if_some(arg, result):
     assert if_some(lambda x: x)(arg) == result
+
+
+@pytest.mark.parametrize(
+    "arg, result",
+    [
+        (3, 3),
+        (None, 10),
+    ],
+)
+def test_if_none(arg, result):
+    assert if_none(lambda _: 10)(arg) == result
 
 
 @pytest.mark.parametrize(

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -125,19 +125,17 @@ async def test_choose_some_future_returns_none_on_empty():
     assert await c(1) is None
 
 
-# TODO rename
-async def less_then_3(x: int) -> int | None:
+async def less_than_3(x: int) -> int | None:
     return x if x < 3 else None
 
 
-# TODO rename
-async def more_then_10(x: int) -> int | None:
+async def more_than_10(x: int) -> int | None:
     return x if x > 10 else None
 
 
 @pytest.mark.asyncio
 async def test_choose_some_future_returns_none_on_failed():
-    c = choose_some_future() | less_then_3 | more_then_10
+    c = choose_some_future() | less_than_3 | more_than_10
     assert await c(6) is None
 
 

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -4,6 +4,7 @@ from pymon.maybe import (
     choose_some,
     choose_some_future,
     if_none,
+    if_none_returns,
     if_some,
     if_some_returns,
 )
@@ -40,6 +41,17 @@ def test_if_none(arg, result):
 )
 def test_if_some_returns(replacement, value, result):
     assert if_some_returns(replacement)(value) == result
+
+
+@pytest.mark.parametrize(
+    "replacement, value, result",
+    [
+        (True, 1, 1),
+        (True, None, True),
+    ],
+)
+def test_if_none_returns(replacement, value, result):
+    assert if_none_returns(replacement)(value) == result
 
 
 @pytest.mark.parametrize(

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -7,6 +7,7 @@ from pymon.maybe import (
     if_none_returns,
     if_some,
     if_some_returns,
+    some_when_future,
 )
 
 
@@ -123,10 +124,12 @@ async def test_choose_some_future_returns_none_on_empty():
     assert await c(1) is None
 
 
+# TODO rename
 async def less_then_3(x: int) -> int | None:
     return x if x < 3 else None
 
 
+# TODO rename
 async def more_then_10(x: int) -> int | None:
     return x if x > 10 else None
 
@@ -135,3 +138,14 @@ async def more_then_10(x: int) -> int | None:
 async def test_choose_some_future_returns_none_on_failed():
     c = choose_some_future() | less_then_3 | more_then_10
     assert await c(6) is None
+
+
+async def more_than_15(x: int) -> bool:
+    return x > 15
+
+
+@pytest.mark.asyncio
+async def test_some_when_future():
+    p = some_when_future(more_than_15)
+    assert await p(10) is None
+    assert await p(16) == 16

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -14,7 +14,6 @@ def test_if_some_returns(replacement, value, result):
     assert if_some_returns(replacement)(value) == result
 
 
-# TODO rename
 @pytest.mark.parametrize(
     "value, funcs, result",
     [
@@ -24,7 +23,7 @@ def test_if_some_returns(replacement, value, result):
         (3, [lambda _: None, lambda x: x + 2], 5),
     ],
 )
-def test_choose(value, funcs, result):
+def test_choose_some(value, funcs, result):
     c = choose_some()
 
     for func in funcs:
@@ -33,14 +32,12 @@ def test_choose(value, funcs, result):
     assert c(value) == result
 
 
-# TODO rename
-def test_choose_some_returns_error_on_empty():
+def test_choose_some_returns_none_on_empty():
     c = choose_some()
     assert c(1) is None
 
 
-# TODO rename
-def test_choose_some_returns_error_on_failed():
+def test_choose_some_returns_none_on_failed():
     c = (
         choose_some()
         | (lambda x: x if x < 3 else None)

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -7,6 +7,7 @@ from pymon.maybe import (
     if_none_returns,
     if_some,
     if_some_returns,
+    some_when,
     some_when_future,
 )
 
@@ -138,6 +139,12 @@ async def more_then_10(x: int) -> int | None:
 async def test_choose_some_future_returns_none_on_failed():
     c = choose_some_future() | less_then_3 | more_then_10
     assert await c(6) is None
+
+
+def test_some_when():
+    p = some_when(lambda x: x > 15)
+    assert p(10) is None
+    assert p(16) == 16
 
 
 async def more_than_15(x: int) -> bool:

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -1,6 +1,17 @@
 import pytest
 
-from pymon.maybe import choose_some, choose_some_future, if_some_returns
+from pymon.maybe import choose_some, choose_some_future, if_some, if_some_returns
+
+
+@pytest.mark.parametrize(
+    "arg, result",
+    [
+        (3, 3),
+        (None, None),
+    ],
+)
+def test_if_some(arg, result):
+    assert if_some(lambda x: x)(arg) == result
 
 
 @pytest.mark.parametrize(

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -11,6 +11,8 @@ from pymon.result import (
     if_error_returns,
     if_ok,
     if_ok_returns,
+    ok_when,
+    ok_when_future,
 )
 
 
@@ -61,6 +63,23 @@ def test_if_ok_returns(replacement, value, result):
 )
 def test_if_error_returns(replacement, value, result):
     assert if_error_returns(replacement)(value) == result
+
+
+def test_ok_when():
+    p = ok_when(lambda x: x > 15, lambda _: TestError())
+    assert p(10) == TestError()
+    assert p(16) == 16
+
+
+async def more_than_15(x: int) -> bool:
+    return x > 15
+
+
+@pytest.mark.asyncio
+async def test_ok_when_future():
+    p = ok_when_future(more_than_15, lambda _: TestError())
+    assert await p(10) == TestError()
+    assert await p(16) == 16
 
 
 @pytest.mark.parametrize(

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -13,6 +13,7 @@ from pymon.result import (
     if_ok_returns,
     ok_when,
     ok_when_future,
+    safe,
 )
 
 
@@ -52,6 +53,17 @@ def test_if_error(arg, result):
 )
 def test_if_ok_returns(replacement, value, result):
     assert if_ok_returns(replacement)(value) == result
+
+
+def test_safe():
+    @safe
+    def test_func(x: int):
+        if x > 10:
+            raise TestError()
+        return x
+
+    assert test_func(5) == 5
+    assert test_func(20) == TestError()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -14,6 +14,7 @@ from pymon.result import (
     ok_when,
     ok_when_future,
     safe,
+    safe_future,
 )
 
 
@@ -64,6 +65,18 @@ def test_safe():
 
     assert test_func(5) == 5
     assert test_func(20) == TestError()
+
+
+@pytest.mark.asyncio
+async def test_safe_future():
+    @safe_future
+    async def test_func(x: int):
+        if x > 10:
+            raise TestError()
+        return x
+
+    assert await test_func(5) == 5
+    assert await test_func(20) == TestError()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import pytest
 
 from pymon.result import (
@@ -5,7 +7,60 @@ from pymon.result import (
     FailedChooseOkError,
     choose_ok,
     choose_ok_future,
+    if_error,
+    if_error_returns,
+    if_ok,
+    if_ok_returns,
 )
+
+
+@dataclass
+class TestError(Exception):  # noqa
+    ...
+
+
+@pytest.mark.parametrize(
+    "arg, result",
+    [
+        (3, 3),
+        (TestError(), TestError()),
+    ],
+)
+def test_if_ok(arg, result):
+    assert if_ok(lambda x: x)(arg) == result
+
+
+@pytest.mark.parametrize(
+    "arg, result",
+    [
+        (3, 3),
+        (TestError(), 10),
+    ],
+)
+def test_if_error(arg, result):
+    assert if_error(lambda _: 10)(arg) == result
+
+
+@pytest.mark.parametrize(
+    "replacement, value, result",
+    [
+        (True, 1, True),
+        (True, TestError(), TestError()),
+    ],
+)
+def test_if_ok_returns(replacement, value, result):
+    assert if_ok_returns(replacement)(value) == result
+
+
+@pytest.mark.parametrize(
+    "replacement, value, result",
+    [
+        (True, 1, 1),
+        (True, TestError(), True),
+    ],
+)
+def test_if_error_returns(replacement, value, result):
+    assert if_error_returns(replacement)(value) == result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Add test for `future` (#30)
- Add test for `future.returns` (#30)
- Add test for `future.__lshift__` (#30)
- Add test for `future.__rshift__` (#30)
- Add tests for `pipe.__lshift__` (#30)
- Add test for `pipe.__rshift__` (#30)
- Add test for `pipe.finish` (#30)
- Add test for `pipe.returns` (#30)
- Add test for `this` (#30)
- Add test for `this_future` (#30)
- Add test for `returns` (#30)
- Add tests for `returns_future` (#30)
- Fix todos for `maybe` tests (#30)
- Add test for `if_some` (#30)
- Add tests for `if_none` (#30)
- Add tests for `if_none_returns` (#30)
- Rename `check` to `ok_when` (#95)
- Reimplemnt `some_when` via if (#96)
- Add docstring example for `some_when` (#96)
- Add `some_when_future` (#96)
- Add test for `some_when_future` (#96)
- Add test for `some_when` (#30)
- Fix todos in tests for maybe (#30)
- Add `if_ok_returns` (#30)
- Add tests for `if_ok`, `if_error`, `if_ok_returns`, `if_error_returns` (#30)
- Add test for `ok_when`, `ok_when_future` (#30)
- Fix try-except for `safe` and `safe_future` (#30)
- Add test for `safe` (#30)
- Add test for `safe_future` (#30)
- Add codecov config (#30)
- Add code coverage report generation (#30)
