### PR TITLE
#77 Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ def encode(encoding: str, data: str) -> bytes:
   return data.encode(encoding)
 
 result = (
-  Pipe("Hello, world!")
+  pipe("Hello, world!")
   << split(" ")
   << cmap(encode("UTF-8"))
   << list

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # ▶️ pymon
 
-`pymon` is an API for writing functional pipelines with Python3.10+.
+`pymon` is an API for writing functional pipelines with Python3.10+. It is
+developed with Domain Driven Design in mind and highly inspired by the concepts
+of functional domain modelling.
 
-## Basics
+## Features
 
 ### `pipe` and `future`
 
@@ -41,10 +43,10 @@ each `<<` step value returned by passed function is wrapped into `pipe`
 container for further chaining.
 
 If your function returns `pipe` object that to unpack that one can use
-`@pipeline` decorator.
+`@pipe.returns` decorator.
 
 ```python
-@pipeline
+@pipe.returns
 def parse_http_query(query: bytes) -> dict:
   return (
     pipe(query)
@@ -77,6 +79,15 @@ result = await (
 `future` does not have `finish` method like `pipe` as it is awaitable and in
 some sense it has built-in unpacking keyword - `await`.
 
+Also sometimes it might be useful to wrap value returns by async function into
+future. For that one can use `@future.returns` decorator:
+
+```py
+@future.returns
+async def some_future_function(arg: int) -> bool:
+  ...
+```
+
 Basically the way this containers map to each other looks like this. While we
 work with `pipe` and sync functions we use `<<` and remain in `pipe` context.
 But right at the moment we need to apply some async function `future` comes out
@@ -92,6 +103,85 @@ graph LR;
   future --"<<"--> future
   future --">>"--> future
 ```
+
+This scheme describes how `pipe` and `future` convert to each other during
+pipeline execution.
+
+`pipe` and `future` are main building blocks for functional pipelines.
+
+### Composition
+
+Function composition is important feature that allows us to build functions on
+the fly. For that `pymon` provides special `compose` function (actually it is
+class). It has the same interface as `pipe`/`future` but does not take input
+argument:
+
+```py
+parse_http_query: Callable[[bytes], dict] = (
+  compose()
+  << some_when(is_not_empty)
+  << if_some(bytes_decode("UTF-8"))
+  << if_some(str_split("&"))
+  << if_some(cmap(str_split("=")))
+  << if_some(dict)
+  << if_none(returns({}))
+)
+```
+
+Sync functions are composed with `<<` and async with `>>`. I suggest providing
+type annotation for functions created via `compose`, especially it is important
+for domain modelling.
+
+### Maybe monad
+
+`pymon` does not provide dedicated `Maybe` monad with dedicates containers like
+`Just`/`Some` and `Nothing`, but provides multiple functions for handling
+`None`:
+
+- `if_some`
+- `if_none`
+- `if_some_returns`
+- `if_none_returns`
+- `some_when`
+- `some_when_future`
+- `choose_some`
+- `choose_some_future`
+
+### Result monad
+
+`Result` monad also known as `Either` is not provided by `pymon` too. But there
+is interface for handling `Exception` objects:
+
+- `if_ok`
+- `if_error`
+- `if_ok_returns`
+- `if_error_returns`
+- `ok_when`
+- `ok_when_future`
+- `choose_ok`
+- `choose_ok_future`
+- `safe`
+- `safe_future`
+
+### Predicates
+
+Often we have some expressions that return boolean values (logical). To provide
+composition for such functions - predicates - there are 2 combinators: `each`
+and `one`.
+
+`each` performs logical AND operation across predicates and stands for
+mathematical conjunction. `one` on the other hand performs logical OR and
+implements disjunction.
+
+```py
+p = (
+  one()
+  << (each() << (lambda x: x > 3) << (lambda x: x < 10))
+  << (each() << (lambda x: x > 23) << (lambda x: x < 55))
+)
+```
+
+### FAQ
 
 #### But why only one argument functions are supported?
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -8,6 +8,7 @@ Full list of [Pymon](README.md#-pymon) project modules.
 - [Pymon](pymon/index.md#pymon)
     - [Core](pymon/core.md#core)
     - [Maybe](pymon/maybe.md#maybe)
+    - [Model](pymon/model.md#model)
     - [Pointfree](pymon/pointfree/index.md#pointfree)
         - [Bytes Utils](pymon/pointfree/bytes_utils.md#bytes-utils)
         - [Dict Utils](pymon/pointfree/dict_utils.md#dict-utils)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,16 +2,23 @@
 
 > Auto-generated documentation index.
 
-`pymon` is an API for writing functional pipelines with Python3.10+.
+`pymon` is an API for writing functional pipelines with Python3.10+. It is
+developed with Domain Driven Design in mind and highly inspired by the concepts
+of functional domain modelling.
 
 Full Pymon project documentation can be found in [Modules](MODULES.md#pymon-modules)
 
 - [▶️ pymon](#-pymon)
-    - [Basics](#basics)
+    - [Features](#features)
         - [`pipe` and `future`](#pipe-and-future)
+        - [Composition](#composition)
+        - [Maybe monad](#maybe-monad)
+        - [Result monad](#result-monad)
+        - [Predicates](#predicates)
+        - [FAQ](#faq)
   - [Pymon Modules](MODULES.md#pymon-modules)
 
-## Basics
+## Features
 
 ### `pipe` and `future`
 
@@ -50,10 +57,10 @@ each `<<` step value returned by passed function is wrapped into `pipe`
 container for further chaining.
 
 If your function returns `pipe` object that to unpack that one can use
-`@pipeline` decorator.
+`@pipe.returns` decorator.
 
 ```python
-@pipeline
+@pipe.returns
 def parse_http_query(query: bytes) -> dict:
   return (
     pipe(query)
@@ -86,6 +93,15 @@ result = await (
 `future` does not have `finish` method like `pipe` as it is awaitable and in
 some sense it has built-in unpacking keyword - `await`.
 
+Also sometimes it might be useful to wrap value returns by async function into
+future. For that one can use `@future.returns` decorator:
+
+```py
+@future.returns
+async def some_future_function(arg: int) -> bool:
+  ...
+```
+
 Basically the way this containers map to each other looks like this. While we
 work with `pipe` and sync functions we use `<<` and remain in `pipe` context.
 But right at the moment we need to apply some async function `future` comes out
@@ -101,6 +117,85 @@ graph LR;
   future --"<<"--> future
   future --">>"--> future
 ```
+
+This scheme describes how `pipe` and `future` convert to each other during
+pipeline execution.
+
+`pipe` and `future` are main building blocks for functional pipelines.
+
+### Composition
+
+Function composition is important feature that allows us to build functions on
+the fly. For that `pymon` provides special `compose` function (actually it is
+class). It has the same interface as `pipe`/`future` but does not take input
+argument:
+
+```py
+parse_http_query: Callable[[bytes], dict] = (
+  compose()
+  << some_when(is_not_empty)
+  << if_some(bytes_decode("UTF-8"))
+  << if_some(str_split("&"))
+  << if_some(cmap(str_split("=")))
+  << if_some(dict)
+  << if_none(returns({}))
+)
+```
+
+Sync functions are composed with `<<` and async with `>>`. I suggest providing
+type annotation for functions created via `compose`, especially it is important
+for domain modelling.
+
+### Maybe monad
+
+`pymon` does not provide dedicated `Maybe` monad with dedicates containers like
+`Just`/`Some` and `Nothing`, but provides multiple functions for handling
+`None`:
+
+- `if_some`
+- `if_none`
+- `if_some_returns`
+- `if_none_returns`
+- `some_when`
+- `some_when_future`
+- `choose_some`
+- `choose_some_future`
+
+### Result monad
+
+`Result` monad also known as `Either` is not provided by `pymon` too. But there
+is interface for handling `Exception` objects:
+
+- `if_ok`
+- `if_error`
+- `if_ok_returns`
+- `if_error_returns`
+- `ok_when`
+- `ok_when_future`
+- `choose_ok`
+- `choose_ok_future`
+- `safe`
+- `safe_future`
+
+### Predicates
+
+Often we have some expressions that return boolean values (logical). To provide
+composition for such functions - predicates - there are 2 combinators: `each`
+and `one`.
+
+`each` performs logical AND operation across predicates and stands for
+mathematical conjunction. `one` on the other hand performs logical OR and
+implements disjunction.
+
+```py
+p = (
+  one()
+  << (each() << (lambda x: x > 3) << (lambda x: x < 10))
+  << (each() << (lambda x: x > 23) << (lambda x: x < 55))
+)
+```
+
+### FAQ
 
 #### But why only one argument functions are supported?
 
@@ -142,7 +237,7 @@ def encode(encoding: str, data: str) -> bytes:
   return data.encode(encoding)
 
 result = (
-  Pipe("Hello, world!")
+  pipe("Hello, world!")
   << split(" ")
   << cmap(encode("UTF-8"))
   << list

--- a/docs/pymon/core.md
+++ b/docs/pymon/core.md
@@ -3,53 +3,47 @@
 > Auto-generated documentation for [pymon.core](https://github.com/katunilya/pymon/blob/main/pymon/core.py) module.
 
 - [Pymon](../README.md#-pymon) / [Modules](../MODULES.md#pymon-modules) / [Pymon](index.md#pymon) / Core
-    - [Func](#func)
-    - [FutureFunc](#futurefunc)
+    - [compose](#compose)
     - [future](#future)
+        - [future.returns](#futurereturns)
     - [pipe](#pipe)
         - [pipe().finish](#pipefinish)
+        - [pipe.returns](#pipereturns)
     - [cfilter](#cfilter)
     - [cmap](#cmap)
     - [foldl](#foldl)
     - [foldr](#foldr)
-    - [func](#func)
-    - [future_func](#future_func)
     - [hof1](#hof1)
     - [hof2](#hof2)
     - [hof3](#hof3)
-    - [pipeline](#pipeline)
     - [returns](#returns)
-    - [returns_async](#returns_async)
     - [returns_future](#returns_future)
     - [this](#this)
-    - [this_async](#this_async)
+    - [this_future](#this_future)
 
-## Func
+## compose
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L163)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L268)
 
 ```python
-dataclass(slots=True, frozen=True)
-class Func(Generic[P, V]):
+dataclass(slots=True, init=False)
+class compose(Generic[P, V]):
+    def __init__() -> None:
 ```
 
 Function composition abstraction.
 
-#### See also
+If no function is passed to composition than `Exception` would be raised on call.
 
-- [P](#p)
-- [V](#v)
-
-## FutureFunc
-
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L141)
+Example
 
 ```python
-dataclass(slots=True, frozen=True)
-class FutureFunc(Generic[P, V]):
+f: Callable[[int], int] = (
+    compose()
+    << (lambda x: x + 1)
+    << (lambda x: x ** 2)
+)
 ```
-
-Abstraction over async function.
 
 #### See also
 
@@ -58,7 +52,7 @@ Abstraction over async function.
 
 ## future
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L23)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L25)
 
 ```python
 dataclass(slots=True, frozen=True)
@@ -82,9 +76,35 @@ result = await (
 
 - [T](#t)
 
+### future.returns
+
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L55)
+
+```python
+@staticmethod
+def returns(func: Callable[P, Coroutine[Any, Any, T]]):
+```
+
+Wraps returned value of async function to [future](#future).
+
+Return value of function is wrapped into [future](#future).
+
+Example
+
+```python
+@future.returns
+async def some_async_func(x: int, y: int) -> str:
+    ...
+```
+
+#### See also
+
+- [P](#p)
+- [T](#t)
+
 ## pipe
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L69)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L80)
 
 ```python
 dataclass(slots=True, frozen=True)
@@ -110,13 +130,24 @@ result: int = (
 
 ### pipe().finish
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L90)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L101)
 
 ```python
 def finish() -> T:
 ```
 
 Finish [pipe](#pipe) by unpacking internal value.
+
+#### Examples
+
+```python
+result = (
+    pipe(3)
+    << (lambda x: x + 1)
+    << (lambda x: x**2)
+)
+value = result.finish()
+```
 
 #### Returns
 
@@ -126,9 +157,40 @@ Finish [pipe](#pipe) by unpacking internal value.
 
 - [T](#t)
 
+### pipe.returns
+
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L118)
+
+```python
+@staticmethod
+def returns(func: Callable[P, pipe[T]]) -> Callable[P, T]:
+```
+
+Decorator for functions that return [pipe](#pipe) object for seamless unwrapping.
+
+Example
+
+```python
+@pipe.returns
+def some_function(x: int) -> pipe[bool]:
+    return (
+        pipe(x)
+        << (lambda x: x + 1)
+        << some_when(lambda x: x > 10)
+        << if_some_returns(True)
+        << if_none_returns(False)
+
+# returned type is bool
+```
+
+#### See also
+
+- [P](#p)
+- [T](#t)
+
 ## cfilter
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L285)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L401)
 
 ```python
 @hof1
@@ -156,7 +218,7 @@ predicate (Callable[[A1], bool]): to filter with.
 
 ## cmap
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L271)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L387)
 
 ```python
 @hof1
@@ -182,7 +244,7 @@ mapper (Callable[[A1], A2]): mapper for element of iterable.
 
 ## foldl
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L241)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L357)
 
 ```python
 @hof2
@@ -213,7 +275,7 @@ folder (Callable[[A1, A2], A1]): aggregator.
 
 ## foldr
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L256)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L372)
 
 ```python
 @hof2
@@ -242,39 +304,9 @@ folder (Callable[[A1, A2], A2]): aggregator.
 - [A2](#a2)
 - [hof2](#hof2)
 
-## func
-
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L184)
-
-```python
-def func(func: Callable[P, V]) -> Func[P, V]:
-```
-
-Decorator for making functions composable.
-
-#### See also
-
-- [P](#p)
-- [V](#v)
-
-## future_func
-
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L189)
-
-```python
-def future_func(func: Callable[P, Awaitable[V]]) -> FutureFunc[P, V]:
-```
-
-Decorator for making async functions composable.
-
-#### See also
-
-- [P](#p)
-- [V](#v)
-
 ## hof1
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L202)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L318)
 
 ```python
 def hof1(f: Callable[Concatenate[A1, P], AResult]):
@@ -290,7 +322,7 @@ Separate first argument from other.
 
 ## hof2
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L215)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L331)
 
 ```python
 def hof2(f: Callable[Concatenate[A1, A2, P], AResult]):
@@ -307,7 +339,7 @@ Separate first 2 arguments from other.
 
 ## hof3
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L228)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L344)
 
 ```python
 def hof3(f: Callable[Concatenate[A1, A2, A3, P], AResult]):
@@ -323,24 +355,9 @@ Separate first 3 arguments from other.
 - [AResult](#aresult)
 - [P](#p)
 
-## pipeline
-
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L99)
-
-```python
-def pipeline(func: Callable[P, pipe[T]]) -> Callable[P, T]:
-```
-
-Decorator for functions that return `Pipe` object for seamless unwrapping.
-
-#### See also
-
-- [P](#p)
-- [T](#t)
-
 ## returns
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L122)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L167)
 
 ```python
 def returns(x: T) -> Callable[P, T]:
@@ -348,20 +365,11 @@ def returns(x: T) -> Callable[P, T]:
 
 Return `T` on any input.
 
-#### See also
-
-- [P](#p)
-- [T](#t)
-
-## returns_async
-
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L131)
+Example
 
 ```python
-def returns_async(x: T) -> Callable[P, future[T]]:
+get_none: Callable[..., None] = returns(None)
 ```
-
-Return awaitable `T` on any input.
 
 #### See also
 
@@ -370,13 +378,19 @@ Return awaitable `T` on any input.
 
 ## returns_future
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L54)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L181)
 
 ```python
-def returns_future(func: Callable[P, T]):
+def returns_future(x: T) -> Callable[P, future[T]]:
 ```
 
-Wraps returned value of async function to [future](#future).
+Return awaitable `T` on any input.
+
+Example
+
+```python
+get_none_future: Callable[..., future[None]] = returns_future(None)
+```
 
 #### See also
 
@@ -385,27 +399,40 @@ Wraps returned value of async function to [future](#future).
 
 ## this
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L112)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L146)
 
 ```python
-def this(x: T) -> T:
+def this(args: T) -> T:
 ```
 
 Synchronous identity function.
+
+Example
+
+```python
+this(3)  # 3
+```
 
 #### See also
 
 - [T](#t)
 
-## this_async
+## this_future
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L117)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/core.py#L156)
 
 ```python
-async def this_async(x: T) -> T:
+@future.returns
+async def this_future(args: T) -> T:
 ```
 
 Asynchronous identity function.
+
+Example
+
+```python
+this_future(3)  # future(3)
+```
 
 #### See also
 

--- a/docs/pymon/index.md
+++ b/docs/pymon/index.md
@@ -6,6 +6,7 @@
     - Modules
         - [Core](core.md#core)
         - [Maybe](maybe.md#maybe)
+        - [Model](model.md#model)
         - [Pointfree](pointfree/index.md#pointfree)
         - [Predicate](predicate.md#predicate)
         - [Result](result.md#result)

--- a/docs/pymon/maybe.md
+++ b/docs/pymon/maybe.md
@@ -3,21 +3,95 @@
 > Auto-generated documentation for [pymon.maybe](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py) module.
 
 - [Pymon](../README.md#-pymon) / [Modules](../MODULES.md#pymon-modules) / [Pymon](index.md#pymon) / Maybe
+    - [choose_some](#choose_some)
+    - [choose_some_future](#choose_some_future)
     - [if_none](#if_none)
     - [if_none_returns](#if_none_returns)
     - [if_some](#if_some)
     - [if_some_returns](#if_some_returns)
     - [some_when](#some_when)
+    - [some_when_future](#some_when_future)
+
+## choose_some
+
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L159)
+
+```python
+dataclass(slots=True, init=False)
+class choose_some(Generic[P, T]):
+    def __init__() -> None:
+```
+
+Combines multiple sync functions into switch-case like statement.
+
+The first function to return non-`None` result is used. If no function passed than
+`None` is returned. Uses deepcopy to keep arguments immutable during attempts.
+
+Examples
+
+```python
+f = (
+    choose_some()
+    | create_linked_node
+    | create_isolated_node
+)
+```
+
+#### See also
+
+- [P](#p)
+- [T](#t)
+
+## choose_some_future
+
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L196)
+
+```python
+dataclass(slots=True, init=False)
+class choose_some_future(Generic[P, T]):
+    def __init__() -> None:
+```
+
+Combines multiple sync functions into switch-case like statement.
+
+The first function to return non-`None` result is used. If no function passed than
+`None` is returned. Uses deepcopy to keep arguments immutable during attempts.
+
+Examples
+
+```python
+f = (
+    choose_some_future()
+    | create_linked_node
+    | create_isolated_node
+)
+```
+
+#### See also
+
+- [P](#p)
+- [T](#t)
 
 ## if_none
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L24)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L38)
 
 ```python
 def if_none(func: Callable[[T], V]):
 ```
 
 Decorator that executes some function only on `None` input.
+
+Example
+
+```python
+result = (
+    pipe({"body": b"hello", "status": 200})
+    << (lambda dct: dct.get("Hello", None))
+    << if_some(bytes_decode("UTF-8"))
+    << if_none(lambda _: "")
+)
+```
 
 #### See also
 
@@ -26,7 +100,7 @@ Decorator that executes some function only on `None` input.
 
 ## if_none_returns
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L38)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L62)
 
 ```python
 @hof1
@@ -34,6 +108,17 @@ def if_none_returns(replacement: V, value: T) -> V | T:
 ```
 
 Replace `value` with `replacement` if one is `None`.
+
+#### Examples
+
+```python
+result = (
+    pipe({"body": b"hello", "status": 200})
+    << (lambda dct: dct.get("Hello", None))
+    << if_some(bytes_decode("UTF-8"))
+    << if_none_returns("")
+)
+```
 
 #### Arguments
 
@@ -52,13 +137,24 @@ V | T: some result.
 
 ## if_some
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L10)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L14)
 
 ```python
 def if_some(func: Callable[[T], V]):
 ```
 
 Decorator that protects function from being executed on `None` value.
+
+Example
+
+```python
+result = (
+    pipe({"body": b"hello", "status": 200})
+    << (lambda dct: dct.get("Hello", None))
+    << if_some(bytes_decode("UTF-8"))
+    << if_none(lambda _: "")
+)
+```
 
 #### See also
 
@@ -67,7 +163,7 @@ Decorator that protects function from being executed on `None` value.
 
 ## if_some_returns
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L56)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L89)
 
 ```python
 @hof1
@@ -75,6 +171,17 @@ def if_some_returns(replacement: V, value: T) -> V | T:
 ```
 
 Replace some `value` when it is not `None`.
+
+#### Examples
+
+```python
+result = (
+    pipe({"body": b"hello", "status": 200})
+    << (lambda dct: dct.get("Hello", None))
+    << if_some_returns(True)
+    << if_none_returns(False)
+)
+```
 
 #### Arguments
 
@@ -93,7 +200,7 @@ V | T: some result.
 
 ## some_when
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L74)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L116)
 
 ```python
 @hof1
@@ -101,6 +208,47 @@ def some_when(predicate: Callable[[T], bool], data: T) -> T | None:
 ```
 
 Passes value next only when predicate is True, otherwise returns `None`.
+
+#### Examples
+
+```python
+policy = some_when(lambda x: x > 3)
+```
+
+#### Arguments
+
+predicate (Callable[[T], bool]): to fulfill.
+- `data` *T* - to process.
+
+#### Returns
+
+T | None: result.
+
+#### See also
+
+- [T](#t)
+- [hof1](core.md#hof1)
+
+## some_when_future
+
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/maybe.py#L134)
+
+```python
+@hof1
+@future.returns
+async def some_when_future(
+    predicate: Callable[[T], Awaitable[bool]],
+    data: T,
+) -> T | None:
+```
+
+Passes value next only when predicate is True, otherwise returns `None`.
+
+#### Examples
+
+```python
+policy = some_when_future(more_than_3)
+```
 
 #### Arguments
 

--- a/docs/pymon/model.md
+++ b/docs/pymon/model.md
@@ -1,0 +1,53 @@
+# Model
+
+> Auto-generated documentation for [pymon.model](https://github.com/katunilya/pymon/blob/main/pymon/model.py) module.
+
+- [Pymon](../README.md#-pymon) / [Modules](../MODULES.md#pymon-modules) / [Pymon](index.md#pymon) / Model
+    - [Auditable](#auditable)
+    - [Entity](#entity)
+    - [Signed](#signed)
+
+## Auditable
+
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/model.py#L27)
+
+```python
+class Auditable(Signed[TAuthor], Protocol):
+```
+
+Type that has time information about it changes.
+
+#### See also
+
+- [TAuthor](#tauthor)
+
+## Entity
+
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/model.py#L7)
+
+```python
+class Entity(Protocol, Generic[TId]):
+```
+
+Common type for Entities in terms of Domain Driven Design.
+
+Entity has identity and even when 2 Entities contain exactly the same data, but
+differentiate in terms of identities they are considered different.
+
+#### See also
+
+- [TId](#tid)
+
+## Signed
+
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/model.py#L20)
+
+```python
+class Signed(Protocol, Generic[TAuthor]):
+```
+
+Type that has information about its author.
+
+#### See also
+
+- [TAuthor](#tauthor)

--- a/docs/pymon/predicate.md
+++ b/docs/pymon/predicate.md
@@ -3,55 +3,68 @@
 > Auto-generated documentation for [pymon.predicate](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py) module.
 
 - [Pymon](../README.md#-pymon) / [Modules](../MODULES.md#pymon-modules) / [Pymon](index.md#pymon) / Predicate
-    - [FuturePredicate](#futurepredicate)
-    - [Predicate](#predicate)
-    - [future_predicate](#future_predicate)
+    - [each](#each)
+    - [one](#one)
     - [is_empty](#is_empty)
     - [is_not_empty](#is_not_empty)
     - [len_less_or_equals](#len_less_or_equals)
     - [len_less_then](#len_less_then)
     - [len_more_or_equals](#len_more_or_equals)
     - [len_more_then](#len_more_then)
-    - [predicate](#predicate)
 
-## FuturePredicate
+## each
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L11)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L44)
 
 ```python
-class FuturePredicate(FutureFunc[P, bool]):
+dataclass(slots=True, init=False)
+class each(Generic[P]):
+    def __init__() -> None:
 ```
 
-Abstraction over async predicates.
+Mathematical conjunction of predicates.
+
+If no predicate passed returns True.
+
+Example
+
+```python
+# returns True if number is between 3 and 10
+p: Callable[[int], bool] = (
+    each()
+    << (lambda x: x > 3)
+    << (lambda x: x < 10)
+)
+```
 
 #### See also
 
 - [P](#p)
 
-## Predicate
+## one
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L60)
-
-```python
-dataclass(slots=True, frozen=True)
-class Predicate(Func[P, bool]):
-```
-
-Abstraction over predicates.
-
-#### See also
-
-- [P](#p)
-
-## future_predicate
-
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L107)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L114)
 
 ```python
-def future_predicate(p: Callable[P, Awaitable[bool]]):
+dataclass(slots=True, init=False)
+class one(Generic[P]):
+    def __init__() -> None:
 ```
 
-Makes function composable [FuturePredicate](#futurepredicate) instance.
+Mathematical disjunction of predicates.
+
+If no predicate passed returns False.
+
+Example
+
+```python
+# returns True for any number that is less than 3 or more than 10
+p: Callable[[int], bool] = (
+    one()
+    << (lambda x < 3)
+    << (lambda x > 10)
+)
+```
 
 #### See also
 
@@ -59,10 +72,9 @@ Makes function composable [FuturePredicate](#futurepredicate) instance.
 
 ## is_empty
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L155)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L189)
 
 ```python
-@predicate
 def is_empty(obj: TSized) -> bool:
 ```
 
@@ -71,14 +83,12 @@ If `obj` is empty.
 #### See also
 
 - [TSized](#tsized)
-- [predicate](#predicate)
 
 ## is_not_empty
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L161)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L194)
 
 ```python
-@predicate
 def is_not_empty(obj: TSized) -> bool:
 ```
 
@@ -87,11 +97,10 @@ If `obj` is not empty.
 #### See also
 
 - [TSized](#tsized)
-- [predicate](#predicate)
 
 ## len_less_or_equals
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L132)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L168)
 
 ```python
 def len_less_or_equals(length: int):
@@ -101,7 +110,7 @@ If `iterable` length is less or equals `length`.
 
 ## len_less_then
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L122)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L159)
 
 ```python
 def len_less_then(length: int):
@@ -111,7 +120,7 @@ If `iterable` length is strictly less than `length`.
 
 ## len_more_or_equals
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L142)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L177)
 
 ```python
 def len_more_or_equals(length: int):
@@ -121,24 +130,10 @@ If `iterable` length is more or equals `length`.
 
 ## len_more_then
 
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L112)
+[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L150)
 
 ```python
 def len_more_then(length: int):
 ```
 
 If `iterable` length is strictly more than `length`.
-
-## predicate
-
-[[find in source code]](https://github.com/katunilya/pymon/blob/main/pymon/predicate.py#L102)
-
-```python
-def predicate(p: Callable[P, bool]):
-```
-
-Makes function composable [Predicate](#predicate) instance.
-
-#### See also
-
-- [P](#p)

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -165,7 +165,12 @@ async def this_future(args: T) -> T:
 
 
 def returns(x: T) -> Callable[P, T]:
-    """Return `T` on any input."""
+    """Return `T` on any input.
+
+    Example::
+
+            get_none: Callable[..., None] = returns(None)
+    """
 
     def _returns(*_: P.args, **__: P.kwargs) -> T:
         return x

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -108,7 +108,21 @@ class pipe(Generic[T]):  # noqa
 
     @staticmethod
     def returns(func: Callable[P, pipe[T]]) -> Callable[P, T]:
-        """Decorator for functions that return `pipe` object for seamless unwrapping."""
+        """Decorator for functions that return `pipe` object for seamless unwrapping.
+
+        Example::
+
+                @pipe.returns
+                def some_function(x: int) -> pipe[bool]:
+                    return (
+                        pipe(x)
+                        << (lambda x: x + 1)
+                        << some_when(lambda x: x > 10)
+                        << if_some_returns(True)
+                        << if_none_returns(False)
+
+                # returned type is bool
+        """
 
         @wraps(func)
         def _wrapper(*args: P.args, **kwargs: P.kwargs) -> T:

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -144,7 +144,12 @@ class pipe(Generic[T]):  # noqa
 
 
 def this(args: T) -> T:
-    """Synchronous identity function."""
+    """Synchronous identity function.
+
+    Example::
+
+            this(3)  # 3
+    """
     return args
 
 

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -101,6 +101,15 @@ class pipe(Generic[T]):  # noqa
     def finish(self) -> T:
         """Finish `pipe` by unpacking internal value.
 
+        Example::
+
+                result = (
+                    pipe(3)
+                    << (lambda x: x + 1)
+                    << (lambda x: x**2)
+                )
+                value = result.finish()
+
         Returns:
             T: internal value
         """

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -195,18 +195,6 @@ def returns_future(x: T) -> Callable[P, future[T]]:
 
 @dataclass(slots=True, init=False)
 class _compose_future(Generic[P, V]):  # noqa
-    """Abstraction over async function.
-
-    If no function is passed to composition than `Exception` would be raised on call.
-
-    Example::
-
-            f: Callable[[int], future[int]] = (
-                compose_future()
-                >> async_add_1
-                << (lambda x: x ** 2)
-            )
-    """
 
     funcs: list
     first_async: bool | None

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -179,7 +179,12 @@ def returns(x: T) -> Callable[P, T]:
 
 
 def returns_future(x: T) -> Callable[P, future[T]]:
-    """Return awaitable `T` on any input."""
+    """Return awaitable `T` on any input.
+
+    Example::
+
+            get_none_future: Callable[..., future[None]] = returns_future(None)
+    """
 
     @future.returns
     async def _returns_future(*_: P.args, **__: P.kwargs) -> T:

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -155,7 +155,12 @@ def this(args: T) -> T:
 
 @future.returns
 async def this_future(args: T) -> T:
-    """Asynchronous identity function."""
+    """Asynchronous identity function.
+
+    Example::
+
+            this_future(3)  # future(3)
+    """
     return args
 
 

--- a/pymon/core.py
+++ b/pymon/core.py
@@ -54,7 +54,16 @@ class future(Generic[T]):  # noqa
 
     @staticmethod
     def returns(func: Callable[P, Coroutine[Any, Any, T]]):
-        """Wraps returned value of async function to `future`."""
+        """Wraps returned value of async function to `future`.
+
+        Return value of function is wrapped into `future`.
+
+        Example::
+
+                @future.returns
+                async def some_async_func(x: int, y: int) -> str:
+                    ...
+        """
 
         @wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> future[T]:

--- a/pymon/maybe.py
+++ b/pymon/maybe.py
@@ -12,7 +12,17 @@ V = TypeVar("V")
 
 
 def if_some(func: Callable[[T], V]):
-    """Decorator that protects function from being executed on `None` value."""
+    """Decorator that protects function from being executed on `None` value.
+
+    Example::
+
+            result = (
+                pipe({"body": b"hello", "status": 200})
+                << (lambda dct: dct.get("Hello", None))
+                << if_some(bytes_decode("UTF-8"))
+                << if_none(lambda _: "")
+            )
+    """
 
     @wraps(func)
     def _wrapper(t: T):

--- a/pymon/maybe.py
+++ b/pymon/maybe.py
@@ -90,6 +90,15 @@ def if_none_returns(replacement: V, value: T) -> V | T:
 def if_some_returns(replacement: V, value: T) -> V | T:
     """Replace some `value` when it is not `None`.
 
+    Example::
+
+            result = (
+                pipe({"body": b"hello", "status": 200})
+                << (lambda dct: dct.get("Hello", None))
+                << if_some_returns(True)
+                << if_none_returns(False)
+            )
+
     Args:
         replacement (V): to replace with.
         value (T): to replace.

--- a/pymon/maybe.py
+++ b/pymon/maybe.py
@@ -36,7 +36,17 @@ def if_some(func: Callable[[T], V]):
 
 
 def if_none(func: Callable[[T], V]):
-    """Decorator that executes some function only on `None` input."""
+    """Decorator that executes some function only on `None` input.
+
+    Example::
+
+            result = (
+                pipe({"body": b"hello", "status": 200})
+                << (lambda dct: dct.get("Hello", None))
+                << if_some(bytes_decode("UTF-8"))
+                << if_none(lambda _: "")
+            )
+    """
 
     @wraps(func)
     def _wrapper(t: T) -> V | None:

--- a/pymon/maybe.py
+++ b/pymon/maybe.py
@@ -63,6 +63,15 @@ def if_none(func: Callable[[T], V]):
 def if_none_returns(replacement: V, value: T) -> V | T:
     """Replace `value` with `replacement` if one is `None`.
 
+    Example::
+
+            result = (
+                pipe({"body": b"hello", "status": 200})
+                << (lambda dct: dct.get("Hello", None))
+                << if_some(bytes_decode("UTF-8"))
+                << if_none_returns("")
+            )
+
     Args:
         replacement (V): to replace with.
         value (T): to replace.

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -20,7 +20,7 @@ def if_ok(func: Callable[[T], V]):
             result = (
                 pipe({"body": b"hello", "status": 200})
                 << safe(lambda dct: dct["Hello"])
-                << if_some(bytes.decode("UTF-8"))
+                << if_ok(bytes.decode("UTF-8"))
                 << if_error(lambda err: str(err))
             )
     """
@@ -44,7 +44,7 @@ def if_error(func: Callable[[T], V]):
             result = (
                 pipe({"body": b"hello", "status": 200})
                 << safe(lambda dct: dct["Hello"])
-                << if_some(bytes.decode("UTF-8"))
+                << if_ok(bytes.decode("UTF-8"))
                 << if_error(lambda err: str(err))
             )
     """

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -44,6 +44,16 @@ def if_error(func: Callable[[T], V]):
 def if_ok_returns(replacement: V, value: T) -> V | T:
     """Replace `value` with `replacement` if one is not `Exception`.
 
+    Example::
+
+            result = (
+                pipe({"body": b"hello", "status": 200})
+                << get("body")
+                << if_ok_returns("Ok")
+                << if_error_returns("")
+            )
+
+
     Args:
         replacement (V): to replace with.
         value (T): to replace.

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -62,6 +62,14 @@ def if_ok_returns(replacement: V, value: T) -> V | T:
 def if_error_returns(replacement: V, value: T) -> V | T:
     """Replace `value` with `replacement` if one is `Exception`.
 
+    Example::
+
+            result = (
+                pipe({"body": "hello", "status": 200})
+                << get("body")
+                << if_error_returns("")
+            )
+
     Args:
         replacement (V): to replace with.
         value (T | TError): to replace.

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -20,7 +20,7 @@ def if_ok(func: Callable[[T], V]):
             result = (
                 pipe({"body": b"hello", "status": 200})
                 << safe(lambda dct: dct["Hello"])
-                << if_ok(bytes.decode("UTF-8"))
+                << if_ok(bytes_decode("UTF-8"))
                 << if_error(lambda err: str(err))
             )
     """
@@ -44,7 +44,7 @@ def if_error(func: Callable[[T], V]):
             result = (
                 pipe({"body": b"hello", "status": 200})
                 << safe(lambda dct: dct["Hello"])
-                << if_ok(bytes.decode("UTF-8"))
+                << if_ok(bytes_decode("UTF-8"))
                 << if_error(lambda err: str(err))
             )
     """

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -13,7 +13,17 @@ TError = TypeVar("TError", bound=Exception)
 
 
 def if_ok(func: Callable[[T], V]):
-    """Decorator that protects function from being executed on `Exception` value."""
+    """Decorator that protects function from being executed on `Exception` value.
+
+    Example::
+
+            result = (
+                pipe({"body": b"hello", "status": 200})
+                << safe(lambda dct: dct["Hello"])
+                << if_some(bytes.decode("UTF-8"))
+                << if_error(lambda err: str(err))
+            )
+    """
 
     @wraps(func)
     def _wrapper(t: T) -> V:

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -99,6 +99,14 @@ def safe_future(func: Callable[P, Awaitable[V]]) -> Callable[P, future[V | TErro
     """Decorator for async function that might raise an exception.
 
     Excepts exception and returns that instead.
+
+    Example::
+
+            @safe_future
+            async def connect_database(conn_str: str) -> Database:
+                return Database(conn_str)
+
+            # type: str -> Database | Exception
     """
 
     @wraps(func)

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -27,7 +27,17 @@ def if_ok(func: Callable[[T], V]):
 
 
 def if_error(func: Callable[[T], V]):
-    """Decorator that executes some function only on `Exception` input."""
+    """Decorator that executes some function only on `Exception` input.
+
+    Example::
+
+            result = (
+                pipe({"body": b"hello", "status": 200})
+                << safe(lambda dct: dct["Hello"])
+                << if_some(bytes.decode("UTF-8"))
+                << if_error(lambda err: str(err))
+            )
+    """
 
     @wraps(func)
     def _wrapper(t: T) -> V | Exception:

--- a/pymon/result.py
+++ b/pymon/result.py
@@ -83,6 +83,14 @@ def safe(func: Callable[P, V]) -> Callable[P, V | Exception]:
     """Decorator for sync function that might raise an exception.
 
     Excepts exception and returns that instead.
+
+    Example::
+
+            @safe
+            def get_key(key: Any, dct: dict) -> Any:
+                return dct[key]  # raises error
+
+            # type: str, dict -> Any | Exception
     """
 
     @wraps(func)


### PR DESCRIPTION
- Add example for `future.returns` (#77)
- Add example docstring for `pipe.returns` (#77)
- Add example docstring for `pipe.finish` (#77)
- Add example docstring for `this` (#77)
- Add example docstring for `this_future` (#77)
- Add docstring for `returns` (#77)
- Add example docstring for `returns_future` (#77)
- Add example docstring for `safe_future` (#77)
- Add example docstring for `safe` (#77)
- Add example docstring for `if_error_returns` (#77)
- Add example docstring for `if_ok_returns` (#77)
- Add example docstring for `if_error` (#77)
- Add example docstring for `if_ok` (#77)
- fixup! Add example docstring for `if_ok` (#77)
- fixup! fixup! Add example docstring for `if_ok` (#77)
- Add example docstring for `if_some` (#77)
- Add example docstring for `if_none` (#77)
- Add example docstring for `if_none_returns` (#77)
- Add example docstring for `if_some_returns` (#77)
- Remove docstring for `_compose_future` utility class (#77)
- Fix `pipe` name in `README.md` line 136 (#77)
- Improve `README.md` (#77)
- Regenerate docs (#77)
